### PR TITLE
Double DQN: Use Q network to choose actions and Q Target network to evaluate the scores of actions.

### DIFF
--- a/bridge-builder/bridge_builder.py
+++ b/bridge-builder/bridge_builder.py
@@ -253,12 +253,12 @@ class Trainer:
         )
 
         q_values_now = self._q.predict(states)
-        next_action = np.argmax(q_values_now, axis=1)
+        next_actions = np.argmax(q_values_now, axis=1)
         td_targets = (
             rewards
             + (1 - is_dones)
             * self._training_state.training_config.gamma
-            * self._q_target.predict(states)[range(len(states)), next_action]
+            * self._q_target.predict(next_states)[np.arange(len(states)), next_actions]
         )
 
         td_errors = td_targets - q_values_now[np.arange(len(actions)), actions]


### PR DESCRIPTION
In our bridge-building case, DQN seems to make this perform worse, since we're scoring based on historical data/scores, which encourage building towers on either side, and penalize dropping blocks in the middle (because blocks dropped in the middle in the past have usually fallen through a hole). Maybe in this case, epsilon needs to be higher, to allow more exploration rather than building off of historical data?

I may also not fully understand! but based off my reading of blog post, that's what I think might be happening.