### PR TITLE
runtime fixes for pr #8

### DIFF
--- a/bridger/builder.py
+++ b/bridger/builder.py
@@ -7,7 +7,7 @@ import torch
 
 from torch.utils.data import DataLoader
 
-from bridger import config, policies, qfunctions, replay_buffer
+import config, policies, qfunctions, replay_buffer
 
 
 # TODO: Add hooks for TrainingHistory

--- a/bridger/config/__init__.py
+++ b/bridger/config/__init__.py
@@ -1,8 +1,8 @@
-from bridger.config.agent import hparam_dict as agent_config
-from bridger.config.buffer import hparam_dict as buffer_config
-from bridger.config.checkpointing import hparam_dict as checkpoint_config
-from bridger.config.env import hparam_dict as env_config
-from bridger.config.training import hparam_dict as training_config
+from config.agent import hparam_dict as agent_config
+from config.buffer import hparam_dict as buffer_config
+from config.checkpointing import hparam_dict as checkpoint_config
+from config.env import hparam_dict as env_config
+from config.training import hparam_dict as training_config
 
 bridger_config = dict(
     **agent_config,

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,6 +17,7 @@ grpcio==1.32.0
 gym==0.17.3
 h5py==2.10.0
 idna==2.10
+ipython==7.22.0
 importlib-metadata==2.0.0
 joblib==0.17.0
 Keras-Preprocessing==1.1.2


### PR DESCRIPTION
tiny PR on top of #8 that could be merged in after, or just cherry-picked

bridger namespace(?directory) import: It looks like you're running the commands from the director that has both rome-blocks and gym-bridges, but it should work fine without the `bridger.` prefix. 

~~Seems like `pl.data_loader` is deprecated: https://forums.pytorchlightning.ai/t/attributeerror-module-pytorch-lightning-has-no-attribute-data-loader/271~~ addressed in #9 