### PR TITLE
Callback testing

### DIFF
--- a/bin/bridge_builder.py
+++ b/bin/bridge_builder.py
@@ -16,8 +16,8 @@
 # Passing the command 'whos' in the ipython shell allows for examination of currently
 # defined variables. When interactive-mode begins, 'whos' command will return the
 # BridgeBuilder object as 'self' and thresholds, a dict mapping some subset of
-# 'episode' and 'step' to the current corresponding indices(as tracked by
-# `_memory_generator #. See _checkpoint() for more details `
+# 'episode' and 'step' to the current corresponding indices (as tracked by
+# `_memory_generator. See _checkpoint() for more details `
 
 import sys
 import torch
@@ -26,7 +26,6 @@ from pytorch_lightning.callbacks import ModelCheckpoint
 
 from bridger import builder
 from bridger.callbacks import DemoCallback, EarlyStoppingCallback, HistoryCallback
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
 
 def test():
@@ -52,19 +51,11 @@ def test():
     if hparams.debug:
         callbacks += [
             EarlyStoppingCallback(
-                monitor="early_stopping_variable_step",
+                monitor="custom_val_loss",
                 min_delta=sys.float_info.epsilon,  # Set to some arbitrarily delta, shouldn't matter how small
                 patience=0,
                 verbose=False,
                 mode="max",
-                strict=True,
-            ),
-            EarlyStoppingCallback(
-                monitor="train_loss_step",
-                min_delta=-float("inf"),
-                patience=0,
-                verbose=False,
-                mode="min",
                 strict=True,
             ),
             HistoryCallback(steps_per_update=MAX_STEPS),

--- a/bridger/builder.py
+++ b/bridger/builder.py
@@ -69,7 +69,7 @@ class BridgeBuilder(pl.LightningModule):
         self._breakpoint = {"step": 0, "episode": 0}
 
         # Set a dummy default stopping metric variable
-        self.early_stopping_variable = 0
+        self._custom_val_loss = 2
 
         if hparams.debug:
             # TODO(arvind): Move as much of this functionality as possible into
@@ -135,7 +135,7 @@ class BridgeBuilder(pl.LightningModule):
                 self._checkpoint({"episode": episode_idx, "step": total_step_idx})
                 start_state, action, end_state, reward, finished = self()
                 if self.hparams.debug:
-                    self.training_history.increment_visit_count(end_state)
+                    self.training_history.increment_visit_count(start_state)
                 yield (
                     episode_idx,
                     step_idx,
@@ -277,14 +277,14 @@ class BridgeBuilder(pl.LightningModule):
 
         loss = self.compute_loss(td_errors, weights=weights)
 
-        # TODO: Increment the early stopping dummy variable which will be implemented by PR #23
-        if self.early_stopping_variable < self.hparams.early_stopping_threshold:
-            self.early_stopping_variable += 1
+        # TODO(lyric): Replace the early stopping dummy variable which will be implemented by PR #23
+        if self._custom_val_loss < self.hparams.custom_val_loss_threshold:
+            self._custom_val_loss += 1
         self.log(
-            "early_stopping_variable",
-            self.early_stopping_variable,
+            "custom_val_loss",
+            self._custom_val_loss,
             on_step=True,
-            on_epoch=True,
+            on_epoch=False,
             prog_bar=False,
             logger=True,
         )

--- a/bridger/builder_test.py
+++ b/bridger/builder_test.py
@@ -1,0 +1,60 @@
+import sys
+import unittest
+
+from bridger import builder
+from bridger.callbacks import EarlyStoppingCallback
+from pytorch_lightning import Trainer
+from pytorch_lightning.callbacks import Callback
+
+
+class CustomCallback(Callback):
+    def __init__(self):
+        self.count = 0
+
+    def on_train_batch_end(
+        self, trainer, model, outputs, batch, batch_idx, dataloader_idx
+    ):
+        self.count += 1
+
+
+class TestEarlyCallback(unittest.TestCase):
+    """
+    Unit-test that checks functionality of EarlyStopping callback using a CustomCallback .
+    """
+
+    def test_early_callback(self):
+        parser = builder.get_hyperparam_parser()
+        hparams = parser.parse_args()
+        # Set the default hyperparameter for testing EarlyCallback functionality to a smaller number of iterations.
+        hparams.custom_val_loss_threshold = 10
+        model = builder.BridgeBuilder(hparams)
+        # Save reference to object to get self.count later
+        custom_callback = CustomCallback()
+
+        callbacks = [
+            custom_callback,
+            EarlyStoppingCallback(
+                monitor="custom_val_loss",
+                min_delta=sys.float_info.epsilon,  # Set to some arbitrarily delta, shouldn't matter how small.
+                patience=0,
+                verbose=False,
+                mode="max",
+                strict=True,
+            ),
+        ]
+        trainer = Trainer(
+            gradient_clip_val=hparams.gradient_clip_val,
+            val_check_interval=int(1e6),
+            default_root_dir=hparams.checkpoint_model_dir,
+            max_steps=hparams.max_training_batches,
+            callbacks=callbacks,
+        )
+
+        trainer.fit(model)
+
+        # Test that the number of counter loops matches the dummy threshold.
+        self.assertEqual(custom_callback.count, hparams.custom_val_loss_threshold)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/bridger/callbacks.py
+++ b/bridger/callbacks.py
@@ -1,11 +1,11 @@
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 import torch
 
 from pytorch_lightning.callbacks import Callback
+from pytorch_lightning.callbacks.early_stopping import EarlyStopping
+
 
 from bridger import builder
 from bridger import training_panel
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
 
 
 class DemoCallback(Callback):
@@ -33,14 +33,13 @@ class DemoCallback(Callback):
 
 
 class EarlyStoppingCallback(EarlyStopping):
-    def on_validation_end(self, trainer, pl_module):
-        pass
+    """A custom early stopping callback that inherits from the default EarlyStopping. We currently use on_train_batch_end as the hook for the callback, as on_validation_end doesn't get called with our current DQN implementation. The original behavior of the inherited EarlyStopping callback runs at the end of every validation epoch, which never triggers since we only have 1 epoch running at any given time. We use iterations/batches to read from the replay buffer, so we callback on_train_batch_end instead. See note from link: https://pytorch-lightning.readthedocs.io/en/latest/common/early_stopping.html"""
 
     def on_train_batch_end(
         self, trainer, model, outputs, batch, batch_idx, dataloader_idx
     ):
-        # The code will error on the first iteration of training since the model doesn't log train_loss until after the first on_train_batch_end in the training_step() function. For the first step, skip checking for early stopping.
-        if model.early_stopping_variable == 1:
+        """Gets called when train batch ends. The current code will error on the first iteration of training without the if statement since the model doesn't log metrics until after the first on_train_batch_end() in the training_step() function. To fix this, we currently skip checking for early stopping in the first step."""
+        if model._custom_val_loss == 3:
             pass
         else:
             self._run_early_stopping_check(trainer)

--- a/bridger/config/training.py
+++ b/bridger/config/training.py
@@ -55,9 +55,10 @@ hparam_dict[key] = {"type": int, "default": 1}
 help_str = "The number of workers to set for the DataLoader"
 hparam_dict[key]["help"] = help_str
 
-key = "early_stopping_threshold"
-hparam_dict[key] = {"type": int, "default": 50}
-help_str = "Dummy metric for determining early stopping criteria"
+key = "custom_val_loss_threshold"
+hparam_dict[key] = {"type": int, "default": 1e10}
+help_str = "Dummy metric for determining early stopping criteria. Dummy counting starts from 1 and not 0."
+hparam_dict[key]["help"] = help_str
 
 key = "gradient_clip_val"
 hparam_dict[key] = {"type": float, "default": 0.5}


### PR DESCRIPTION
Currently added a couple docstring changes to:

1. Usage notes for interactive-mode for self-reference 
2. make_env docstring, also planning to add docstrings to (on_train_start, on_train_batch_end, update_target, record_q_values, make_memories) to better understand the DQN implementation for future callback implementation
3. Added TODO to DemoCallback, going to experiment with the callbacks for standard neural nets in pl to get a better feel for epoch based callback training, then will consider architecture changes with design doc later in this pr or a new one