### PR TITLE
Update .gitignore for checkpoints, README, tensorboard version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 src/
 __pycache__
 .vscode
+checkpoints/

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ scikit-learn==0.23.2
 scipy==1.4.1
 six==1.15.0
 sklearn==0.0
-tensorboard==2.3.0
+tensorboard==2.5.0
 tensorboard-plugin-wit==1.7.0
 tensorflow==2.3.0
 tensorflow-estimator==2.3.0


### PR DESCRIPTION
The only thing here that might be contentious is bumping the tensorboard version from 2.3.0 --> 2.5.0 (which is the current stable release) since my IDE requires the newer version. This shouldn't be a problem since a) tensorboard is the visualization library, and b) during a quick search I don't actually see us using tensorflow in the repo (but I could be mistaken). I ran this locally and it works for me.