### PR TITLE
Rename builder to builder_trainer.

### DIFF
--- a/bin/bridge_builder.py
+++ b/bin/bridge_builder.py
@@ -18,7 +18,7 @@ import torch
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 
-from bridger import builder
+from bridger import builder_trainer
 from bridger.callbacks import DemoCallback, HistoryCallback
 from pathlib import Path
 
@@ -28,10 +28,10 @@ def test():
     MAX_DEMO_EPISODE_LENGTH = 50
     # TODO(arvind): split the args into those relevant for the LightningModule
     #               and those relevant for the Trainer/Callbacks
-    parser = builder.get_hyperparam_parser()
+    parser = builder_trainer.get_hyperparam_parser()
     hparams = parser.parse_args()
     # hparams.debug = True
-    model = builder.BridgeBuilder(hparams)
+    model = builder_trainer.BridgeBuilderTrainer(hparams)
 
     callbacks = [
         # Only retains checkpoint with minimum monitored quantity seen so far.
@@ -58,7 +58,7 @@ def test():
             args=["python3", "-m", "bin.training_viewer"],
             cwd=Path.cwd(),
         )
-    # TODO: After validation logic has been added to BridgeBuilder,
+    # TODO: After validation logic has been added to BridgeBuilderTrainer,
     # 1. Make val_check_interval below a settable parameter with reasonable default
     # 2. Update callback variable above to reflect the validation logic and pass it
     #    to Trainer init below

--- a/bin/training_viewer.py
+++ b/bin/training_viewer.py
@@ -9,15 +9,15 @@ TrainingPanel.
 
 import time
 
-from bridger import builder
+from bridger import builder_trainer
 from bridger.training_history import TrainingHistory
 from bridger.training_panel import TrainingPanel
 
 
 def view_training():
-    parser = builder.get_hyperparam_parser()
+    parser = builder_trainer.get_hyperparam_parser()
     hparams = parser.parse_args()
-    env = builder.make_env(hparams)
+    env = builder_trainer.make_env(hparams)
 
     panel = TrainingPanel(
         states_n=10,
@@ -36,6 +36,7 @@ def view_training():
             panel.update_panel(history.get_history_by_visit_count())
 
         time.sleep(30)
+
 
 if __name__ == "__main__":
     view_training()

--- a/bridger/callbacks.py
+++ b/bridger/callbacks.py
@@ -2,8 +2,9 @@ import torch
 
 from pytorch_lightning.callbacks import Callback
 
-from bridger import builder
+from bridger import builder_trainer
 from bridger import training_panel
+
 
 class DemoCallback(Callback):
     def __init__(self, steps_per_update, max_episode_length):
@@ -18,7 +19,7 @@ class DemoCallback(Callback):
                 self.demo(model, self.max_episode_length)
 
     def demo(self, model, episode_length):
-        env = builder.make_env(model.hparams)
+        env = builder_trainer.make_env(model.hparams)
         policy = model.policy
         state = env.reset()
         for t in range(episode_length):
@@ -30,8 +31,7 @@ class DemoCallback(Callback):
 
 
 class HistoryCallback(Callback):
-    def __init__(
-        self, steps_per_update):
+    def __init__(self, steps_per_update):
         self.frequency = steps_per_update
 
     def on_train_batch_end(

--- a/bridger/debug_worlds.py
+++ b/bridger/debug_worlds.py
@@ -4,7 +4,7 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import Callback
 
 from bridger import training_panel
-from bridger.builder import BridgeBuilder
+from bridger.builder_trainer import BridgeBuilderTrainer
 
 # Creates the smallest world where a bridge can be built. Cycles
 # through a series of actions to build simple episodes into the
@@ -16,7 +16,7 @@ def tiny_world():
 
     MAX_EPISODE_LENGTH = 5
 
-    model = BridgeBuilder.instantiate(
+    model = BridgeBuilderTrainer.instantiate(
         env_width=4,
         env_force_standard_config=True,
         debug=True,


### PR DESCRIPTION
In preparation for the next PR, this one simply renames builder to builder_trainer.

I wanted the 'builder.py' for a new class that will execute construction projects.