### PR TITLE
Direct copy of #62 requirements + changes from tree

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -56,7 +56,7 @@ pylint==2.10.2
 pyparsing==2.4.7
 pytest==6.2.2
 python-dateutil==2.8.1
-pytorch-lightning==1.3.0
+pytorch-lightning==1.4.7
 PyYAML==5.3.1
 regex==2020.11.13
 requests==2.24.0

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         "matplotlib>=3.3.2",
         "parameterized>=0.8.1",
         "pytest>=6.2.2",
-        "pytorch-lightning==1.3.0",
+        "pytorch-lightning==1.4.7",
         "torch>=1.8.0",
     ],
     # TODO: add metadata kwargs if uploading to PyPI


### PR DESCRIPTION
Took this directly from #62 and then ported the only change in the tree which was to bump `pytorch-lightning==1.4.7`. One weird thing now is that with that version bump (between first and second commit in this series) the pip install starts hanging. I'm going to merge this trimmed requirements in, and then try to figure out what might be hanging later so this PR doesn't bitrot again.