### PR TITLE
Create a unified object logger

### DIFF
--- a/bridger/logging/object_logging.py
+++ b/bridger/logging/object_logging.py
@@ -21,7 +21,7 @@ class ObjectLogManager:
     """Provides a unified interface to log pickle-able objects."""
 
     def __init__(self, dirname: str):
-        """Creates directory dirname to store logs. 
+        """Creates directory dirname to store logs.
 
         Clears the contents of the directory if the dirname existed previously.
 
@@ -32,7 +32,7 @@ class ObjectLogManager:
         shutil.rmtree(self._dirname, ignore_errors=True)
         path = pathlib.Path(self._dirname)
         path.mkdir(parents=True, exist_ok=True)
-        
+
         self._object_loggers = {}
 
     def __enter__(self):

--- a/bridger/logging/object_logging_test.py
+++ b/bridger/logging/object_logging_test.py
@@ -12,9 +12,11 @@ from bridger.logging import object_logging
 
 _TMP_DIR = "tmp/nested_tmp"
 
+
 def create_temp_dir():
     path = pathlib.Path(_TMP_DIR)
     path.mkdir(parents=True, exist_ok=True)
+
 
 def delete_temp_dir():
     path = pathlib.Path(_TMP_DIR)


### PR DESCRIPTION
The object logger will be used for various debug logging use-cases, including replacing training history and replay buffer logging. 

The logger buffers and pickle's logged entries and appends them to a file. The reader is an iterable, hiding the fact that the entries were written in batches. 

ObjectLogManager provides the actual unified log experience. New types of entries can be logged by simply calling log with the log_filename (which also serves as a label) and the new entries themselves.

Standard users will not instantiate ObjectLogger directly. 

The BridgeBuilderModel \_\_init\_\_ will be modified to take an ObjectLogManager instance as an argument to store into self.
