### PR TITLE
fix: Pytype check by updating imports

### DIFF
--- a/bridger/qfunctions.py
+++ b/bridger/qfunctions.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn
 import torch.nn.functional as F
 
 

--- a/bridger/qfunctions_test.py
+++ b/bridger/qfunctions_test.py
@@ -2,7 +2,7 @@
 import unittest
 
 import torch
-import qfunctions
+import bridger.qfunctions as qfunctions
 
 
 class QFunctionsTest(unittest.TestCase):


### PR DESCRIPTION
When running the command `pytype .` in the main directory, we run into a couple errors, fixed by the commit below.

Before:

```
(rome) ~/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day (master) % pytype .             22:56:57
Computing dependencies
Analyzing 25 sources with 0 local dependencies
ninja: Entering directory `.pytype'
[1/14] check bridger.qfunctions
FAILED: /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/.pytype/pyi/bridger/qfunctions.pyi 
/Users/josephgmaa/miniconda3/envs/rome/bin/python -m pytype.single --imports_info /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/.pytype/imports/bridger.qfunctions.imports --module-name bridger.qfunctions -V 3.9 -o /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/.pytype/pyi/bridger/qfunctions.pyi --analyze-annotated --nofail --quick /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions.py
File "/Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions.py", line 5, in <module>: No attribute 'Module' on module 'torch.nn' [module-attr]
File "/Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions.py", line 20, in __init__: No attribute 'ModuleList' on module 'torch.nn' [module-attr]
File "/Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions.py", line 20, in __init__: No attribute 'Conv2d' on module 'torch.nn' [module-attr]
File "/Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions.py", line 28, in __init__: No attribute 'ModuleList' on module 'torch.nn' [module-attr]
File "/Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions.py", line 28, in __init__: No attribute 'Linear' on module 'torch.nn' [module-attr]

For more details, see https://google.github.io/pytype/errors.html#module-attr
ninja: build stopped: subcommand failed.
Leaving directory '.pytype'
```

```
(rome) ~/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day (master) % python -m bridger.qfunctions_test
Traceback (most recent call last):
  File "/Users/josephgmaa/miniconda3/envs/rome/lib/python3.9/runpy.py", line 197, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/Users/josephgmaa/miniconda3/envs/rome/lib/python3.9/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/qfunctions_test.py", line 5, in <module>
    import qfunctions
ModuleNotFoundError: No module named 'qfunctions'
```

After:

```
(rome) ~/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day (master) % pytype .             23:01:28
Computing dependencies
Analyzing 25 sources with 0 local dependencies
ninja: Entering directory `.pytype'
[5/5] check bridger.qfunctions_test
Leaving directory '.pytype'
Success: no errors found
```