### PR TITLE
Bump protobuf requirement to silence deprecation warnings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ matplotlib==3.4.3
 numpy==1.21.2
 pytorch-lightning==1.4.7
 torch==1.8.0
+protobuf==3.19.4


### PR DESCRIPTION
Silences warning when running pytests with the `-s` flag:

```
DeprecationWarning: Call to deprecated create function FileDescriptor(). Note: Create unlinked descriptors is going to go away. Please use get/find descriptors from generated code or query the descriptor_pool.
  DESCRIPTOR = _descriptor.FileDescriptor(
```