### PR TITLE
Fix too many open files issue with logging.

### DIFF
--- a/bridger/builder_trainer.py
+++ b/bridger/builder_trainer.py
@@ -1,5 +1,6 @@
 import argparse
 import IPython
+import copy
 import gym
 import numpy as np
 from bridger import builder
@@ -465,9 +466,10 @@ class BridgeBuilderModel(pl.LightningModule):
         )
 
         if self.hparams.debug:
+            batch_copy = copy.deepcopy(batch)
             self._object_log_manager.log(
                 log_entry.TRAINING_BATCH_LOG_ENTRY,
-                log_entry.TrainingBatchLogEntry(batch_idx, *batch, loss),
+                log_entry.TrainingBatchLogEntry(batch_idx, *batch_copy, loss),
             )
 
             triples = zip(states.tolist(), actions.tolist(), td_errors.tolist())


### PR DESCRIPTION
If we run ~1000 step on debug=True, we see

`OSError: [Errno 24] Too many open files                                                                                                                                                                                                                                    
Traceback (most recent call last):                                                                                                                                                                                                                                         
  File "/usr/lib/python3.9/multiprocessing/resource_sharer.py", line 138, in _serve                                                                                                                                                                                        
  File "/usr/lib/python3.9/multiprocessing/connection.py", line 468, in accept                                                                                                                                                                                             
  File "/usr/lib/python3.9/multiprocessing/connection.py", line 614, in accept                                                                                                                                                                                             
  File "/usr/lib/python3.9/socket.py", line 29OSError: [Errno 24] Too many open files`

Based on https://github.com/pytorch/pytorch/issues/11201, the cause is that the batch gets preserved in the ObjectLogger until it's flushed. With a default buffer size of 1000, we are able to hit the file limit with all the batches that can't be gc-ed yet. Changing the buffer size to 2 makes the problem go away. 

The github thread suggests two approaches:
1. Make a copy of the batch.
2. https://pytorch.org/docs/master/multiprocessing.html?highlight=sharing%20strategy#sharing-strategies

This PR goes with 1. The implementation is simple and I confirmed offline that I no longer get the "Too many open files" issue. The copy only happens in debug mode. As we normalize some of the tensors, we will also need to copy fewer objects.

Approach 2 does not feel as safe or satisfying. There are a lot of warnings about switching the file mode to file_system in the link provided. 

To repro: Amend test_training_batch_logging in builder_trainer_test.py to provide _get_trainer(max_steps=1000)