### PR TITLE
fix: Add config file for pytest to silence marker warning

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+markers=integtest: Marks tests as integration tests.


### PR DESCRIPTION
Before:

```
(rome) ~/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day (master) % pytest -k test_get_logged_object_by_id                                                                                   15:38:18
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.9.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day
collected 313 items / 313 deselected                                                                                                                                                                     

============================================================================================ warnings summary ============================================================================================
bridger/replay_buffer_test.py:21
  /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day/bridger/replay_buffer_test.py:21: PytestUnknownMarkWarning: Unknown pytest.mark.integtest - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.integtest

-- Docs: https://docs.pytest.org/en/stable/warnings.html
=================================================================================== 313 deselected, 1 warning in 2.89s ===================================================================================
```

After:
```
(rome) ~/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day (silence-pytest-warning) % pytest -k test_get_logged_object_by_id                                                                   15:41:23
========================================================================================== test session starts ===========================================================================================
platform darwin -- Python 3.9.6, pytest-6.2.2, py-1.10.0, pluggy-0.13.1
rootdir: /Users/josephgmaa/rome-wasnt-built-in-a-day/rome-wasnt-built-in-a-day, configfile: pytest.ini
collected 313 items / 313 deselected                                                                                                                                                                     

======================================================================================== 313 deselected in 2.83s =========================================================================================
```