### PR TITLE
Compare training batch analyzer

### DIFF
--- a/bin/training_batch_comparison_tool.py
+++ b/bin/training_batch_comparison_tool.py
@@ -43,6 +43,7 @@ def main():
             object_log_readers.read_object_log(test_dirname, test_basename),
         )
     ):
+        print(f"Analyzing Entry {entry_index}")
         for field in expected_log_batch_entry.__dataclass_fields__:
             expected_object_log_value = getattr(expected_log_batch_entry, field)
             test_object_log_value = getattr(test_log_batch_entry, field)


### PR DESCRIPTION
A simple script to compare TrainingBatchLogEntry files from the command line. 

Credit goes to @josephmaa for the work in https://github.com/ldoshi/rome-wasnt-built-in-a-day/pull/101, which has been left frozen as is for a few final checks in its more verbose state.