### PR TITLE
Upgrade pytorch lightning. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ gym==0.17.3
 ipython==7.21.0
 matplotlib==3.4.3
 numpy==1.21.2
-pytorch-lightning==1.4.7
+pytorch-lightning==1.6.3
 torch==1.8.0
 protobuf==3.19.4

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "gym-bridges>=0.0.1",
         "numpy>=1.18.5",
         "matplotlib>=3.3.2",
-        "pytorch-lightning==1.4.7",
+        "pytorch-lightning==1.6.3",
         "torch>=1.8.0",
     ],
     # TODO: add metadata kwargs if uploading to PyPI


### PR DESCRIPTION
We are seeing issues with importing the pytorch_lightning.callbacks module. It seems related to: https://stackoverflow.com/questions/71971105/importerror-cannot-import-name-x-from-y (Thanks @josephmaa !)