### PR TITLE
Action inversion analysis

### DIFF
--- a/bin/action_inversion_analysis_tool.py
+++ b/bin/action_inversion_analysis_tool.py
@@ -15,7 +15,7 @@ from bridger.logging import log_entry
 
 
 class PlotReportsDisplayType(enum.IntEnum):
-    _order_ = "EMPTY GROUND BRICK PREFERRED_ACTION " "POLICY_ACTION MATCHING_ACTION"
+    _order_ = "EMPTY GROUND BRICK PREFERRED_ACTION POLICY_ACTION MATCHING_ACTION"
     EMPTY = 0
     GROUND = 1
     BRICK = 2
@@ -159,6 +159,10 @@ class ActionInversionAnalyzer:
         action inversion report following a period of one or more
         batches during which 0 action inversion reports logged.
 
+        This function assumes ActionInversionReportEntry's are
+        iterated in the same order in which they were logged, i.e. in
+        increasing order of batch_idx.
+
         Returns:
           A list of DivergenceEntry to summarize all the divergences.
 
@@ -208,7 +212,7 @@ class ActionInversionAnalyzer:
 
         end = len(self._divergences)
         if end_batch_idx is not None:
-            for i in range(len(self._divergences) - 1, 0 - 1, -1):
+            for i in range(len(self._divergences) - 1, -1, -1):
                 if self._divergences[i].batch_idx <= end_batch_idx:
                     break
                 end = i


### PR DESCRIPTION
Interactive tool to analyze logged action inversion reports.

The tool supports computing and printing report incident rates, divergence events (transitions from 0 to > 0 inversions as batch idx increases), state/action details for the reports of a specific batch idx.

Sample plots:
![ActionInversionReports](https://user-images.githubusercontent.com/2661144/191345906-447b9088-82ed-44d8-bd8d-667b54e2cd3d.png)
![ActionInversionReportsPerBatch](https://user-images.githubusercontent.com/2661144/191345897-09c131b6-bd90-43d5-bb1f-776eff028933.png)
![DivergenceMagnitudes](https://user-images.githubusercontent.com/2661144/191345905-879a9e83-06ae-4b82-a9e4-009b87da3659.png)

The tool got a bit more involved than originally intended and there are no unit tests for the divergence calculations. Proposal to add these if this tool is used beyond the immediate debugging plans for the current network. It's unclear at present if this tool will be useful after we cannot define expected actions so clearly. If it's useful in the current debugging, we can explore ideas to keep it relevant.