### PR TITLE
Log action inversions incident rate to Tensorboard

### DIFF
--- a/bridger/builder_trainer.py
+++ b/bridger/builder_trainer.py
@@ -664,7 +664,9 @@ class BridgeBuilderModel(pl.LightningModule):
                 )
 
         if self.hparams.debug_action_inversion_checker:
-            action_inversion_reports = self._action_inversion_checker.check(                policy=self._validation_policy            )
+            action_inversion_reports = self._action_inversion_checker.check(
+                policy=self._validation_policy
+            )
 
             self.log("action_inversion_incident_rate", len(action_inversion_reports))
 


### PR DESCRIPTION
Log action inversion incident rate to tensorboard.

This will make initial direct comparisons with loss easier. Then further digging can be done with the analyzer tool. 