### PR TITLE
Improve the smoke test run times and quality

### DIFF
--- a/tools/smoke_test.py
+++ b/tools/smoke_test.py
@@ -199,13 +199,13 @@ class ToolsSmokeTest(unittest.TestCase):
         analyzer.plot_incidence_rate()
         analyzer.plot_incidence_rate(start_batch_idx=skip_one_start_batch_idx)
         analyzer.plot_incidence_rate(end_batch_idx=skip_one_end_batch_idx)
-        # Prunes out all data.
+        # Prunes out all divergences so there is no data to plot.
         analyzer.plot_incidence_rate(start_batch_idx=skip_two_start_batch_idx)
 
         analyzer.plot_divergences()
         analyzer.plot_divergences(start_batch_idx=skip_one_start_batch_idx)
         analyzer.plot_divergences(end_batch_idx=skip_one_end_batch_idx)
-        # Prunes out all data.
+        # Prunes out all divergences so there is no data to plot.
         analyzer.plot_divergences(start_batch_idx=skip_two_start_batch_idx)
 
         analyzer.plot_reports(batch_idx=divergences[0].batch_idx)


### PR DESCRIPTION
The original test ran 200 steps and took 40s on @ldoshi 's machine (longer on @josephmaa ).

The new version runs many fewer steps and also hits two divergences instead of 1, improving the coverage of the test functionality.