### PR TITLE
Object log cache for efficient access.

### DIFF
--- a/tools/web/object_log_cache.py
+++ b/tools/web/object_log_cache.py
@@ -99,6 +99,8 @@ class ObjectLogCache:
 
         Raises:
           ValueError on unsupported key.
+          FileNotFoundError if key does not correspond to a backing
+            data file.
 
         """
         if key not in self._loaders:

--- a/tools/web/object_log_cache_test.py
+++ b/tools/web/object_log_cache_test.py
@@ -25,9 +25,13 @@ class ObjectLogCacheTest(unittest.TestCase):
     def test_get_file_does_not_exist(self):
         cache = object_log_cache.ObjectLogCache(log_dir=_OBJECT_LOGGING_DIR)
 
-        self.assertIsNone(
-            cache.get(object_log_cache.ACTION_INVERSION_REPORTS_BY_BATCH_ID_KEY)
+        self.assertRaisesRegex(
+            FileNotFoundError,
+            "action_inversion_report",
+            cache.get,
+            key=object_log_cache.ACTION_INVERSION_REPORTS_BY_BATCH_ID_KEY,
         )
+
         self.assertEqual(
             cache.key_miss_counts[
                 object_log_cache.ACTION_INVERSION_REPORTS_BY_BATCH_ID_KEY
@@ -41,9 +45,13 @@ class ObjectLogCacheTest(unittest.TestCase):
             0,
         )
 
-        self.assertIsNone(
-            cache.get(object_log_cache.ACTION_INVERSION_REPORTS_BY_BATCH_ID_KEY)
+        self.assertRaisesRegex(
+            FileNotFoundError,
+            "action_inversion_report",
+            cache.get,
+            key=object_log_cache.ACTION_INVERSION_REPORTS_BY_BATCH_ID_KEY,
         )
+
         self.assertEqual(
             cache.key_miss_counts[
                 object_log_cache.ACTION_INVERSION_REPORTS_BY_BATCH_ID_KEY


### PR DESCRIPTION
Creates a simple cache to load and store object log files for single-threaded access from the debug visualization web server.

Loading the files imposes a non-trivial delay.