### PR TITLE
Update to the previous Ubuntu LTS version.

### DIFF
--- a/.github/workflows/hook-run-tests.yaml
+++ b/.github/workflows/hook-run-tests.yaml
@@ -2,7 +2,7 @@ name: Run pytest CI for PRs and merges
 on: [pull_request, push]
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: ["3.9.6"]


### PR DESCRIPTION
The change to 22.10 by default for latest breaks our requirement to keep python 3.9. 