### PR TITLE
Seed replay buffer

### DIFF
--- a/bridger/replay_buffer_initializers.py
+++ b/bridger/replay_buffer_initializers.py
@@ -90,7 +90,7 @@ def _standard_configuration_bridge_states(
 def _n_bricks(
     brick_count: int, env: gym.Env
 ) -> Generator[Tuple[Any, Any, Any, Any, Any], None, None]:
-    """Generates distinct experiences from exhautively placing n bricks.
+    """Generates distinct experiences from exhaustively placing n bricks.
 
     Enumerates every permutation of placing n bricks and removes
     duplicate (state, action) pairs.
@@ -169,7 +169,7 @@ def initialize_replay_buffer(
     Raises:
       ValueError: If the strategy generates more experiences than the
         capacity of the replay buffer or if the strategy does not
-        correponding to a known implementation.
+        correspond to a known implementation.
 
     """
 


### PR DESCRIPTION
Several strategies to populate the replay buffer before starting training.

This is current intended for debugging. We may use parts of it for intentionally saving memories across trainings in the future. 

The following PRs will integrate the strategy into training and improve Sibyl for ease of use.