### PR TITLE
Rename get_action_inversion_checker_actions_standard_configuration to have a more general name.

### DIFF
--- a/bridger/builder_trainer.py
+++ b/bridger/builder_trainer.py
@@ -75,15 +75,14 @@ def make_env(
     return env
 
 
-def get_action_inversion_checker_actions_standard_configuration(
+def get_actions_for_standard_configuration(
     env_width: int,
 ) -> List[List[int]]:
-    """Produces action inversion checker actions.
+    """Produces actions to build a bridge in the standard configuration.
 
-    The current ActionInversionChecker implementation presumes an
-    environment of even width where the bridge is built up from edge
-    to edge without intermediate supports. The actions are initialized
-    based on this presumption.
+    The implementation presumes an environment of even width where the
+    bridge is built up from edge to edge without intermediate
+    supports. The actions are initialized based on this presumption.
 
     Args:
       env_width: The width of the environment.
@@ -298,9 +297,7 @@ class BridgeBuilderModel(pl.LightningModule):
 
         self._action_inversion_checker = None
         if self.hparams.debug_action_inversion_checker:
-            actions = get_action_inversion_checker_actions_standard_configuration(
-                self.hparams.env_width
-            )
+            actions = get_actions_for_standard_configuration(self.hparams.env_width)
             self._action_inversion_checker = (
                 action_inversion_checker.ActionInversionChecker(
                     env=self._validation_env, actions=actions

--- a/bridger/builder_trainer_test.py
+++ b/bridger/builder_trainer_test.py
@@ -25,7 +25,6 @@ from bridger import test_utils
 from bridger.test_utils import _OBJECT_LOGGING_DIR
 
 
-
 _ENV_NAME = "gym_bridges.envs:Bridges-v0"
 _DELTA = 1e-6
 
@@ -377,24 +376,20 @@ class BridgeBuilderTrainerTest(unittest.TestCase):
                 debug_action_inversion_checker=True,
             )
 
-    def test_get_action_inversion_checker_actions_standard_configuration_illegal_usage(
+    def test_get_actions_for_standard_configuration_illegal_usage(
         self,
     ):
         """Verifies checking illegal arguments when building the actions sequence."""
         self.assertRaisesRegex(
             ValueError,
             "must be even to use",
-            builder_trainer.get_action_inversion_checker_actions_standard_configuration,
+            builder_trainer.get_actions_for_standard_configuration,
             env_width=7,
         )
 
-    def test_get_action_inversion_checker_actions_standard_configuration(self):
+    def test_get_actions_for_standard_configuration(self):
         """Verifies building the actions sequence."""
-        actions = (
-            builder_trainer.get_action_inversion_checker_actions_standard_configuration(
-                env_width=8
-            )
-        )
+        actions = builder_trainer.get_actions_for_standard_configuration(env_width=8)
         expected = [[0, 1, 2], [6, 5, 4]]
         self.assertEqual(actions, expected)
 

--- a/bridger/replay_buffer_initializers.py
+++ b/bridger/replay_buffer_initializers.py
@@ -62,11 +62,7 @@ def _standard_configuration_bridge_states(
 
     """
 
-    build_actions = (
-        builder_trainer.get_action_inversion_checker_actions_standard_configuration(
-            env.nA
-        )
-    )
+    build_actions = builder_trainer.get_actions_for_standard_configuration(env.nA)
     build_actions_substrings = [
         [build_action[:i] for i in range(len(build_action) + 1)]
         for build_action in build_actions


### PR DESCRIPTION
The actions to produce a bridge in the standard configuration are used in multiple places so we rename get_action_inversion_checker_actions_standard_configuration() to avoid explicit reference to the first use-case, action inversion checking.