### PR TITLE
Split the object_logging into subdirs by experiment

### DIFF
--- a/bin/bridge_builder.py
+++ b/bin/bridge_builder.py
@@ -13,6 +13,9 @@
 # 3. take_action will take the requested action, potentially multiple times, before
 #    returning to the IPython shell
 
+import datetime
+import os
+
 from pytorch_lightning import Trainer
 from pytorch_lightning.callbacks import ModelCheckpoint
 from pytorch_lightning.callbacks import EarlyStopping
@@ -22,6 +25,14 @@ from bridger import builder_trainer
 from bridger.callbacks import DemoCallback
 from pathlib import Path
 from bridger.logging_utils import object_logging
+
+
+def _get_logging_dir(object_logging_base_dir: str, experiment_name: str):
+    return os.path.join(
+        object_logging_base_dir,
+        f"{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}{'_' if experiment_name else ''}{experiment_name}",
+    )
+
 
 _DEMO_CALLBACK_FREQUENCY = 100
 MAX_DEMO_EPISODE_LENGTH = 50
@@ -33,7 +44,7 @@ def run():
     parser = builder_trainer.get_hyperparam_parser()
     hparams = parser.parse_args()
     with object_logging.ObjectLogManager(
-        hparams.object_logging_dir
+        _get_logging_dir(hparams.object_logging_base_dir, hparams.experiment_name)
     ) as object_log_manager:
         if hparams.load_checkpoint_path:
             # TODO(arvind): Decide on and implement the functionality we'd like to

--- a/bridger/config/training.py
+++ b/bridger/config/training.py
@@ -52,9 +52,14 @@ hparam_dict[key] = {"type": bool, "default": False, "action": BooleanOptionalAct
 help_str = "Whether to check and log td errors for debugging purposes"
 hparam_dict[key]["help"] = help_str
 
-key = "object_logging_dir"
+key = "object_logging_base_dir"
 hparam_dict[key] = {"type": str, "default": "object_logging"}
-help_str = "Path to folder in which all object logs will be saved"
+help_str = "Path to the base folder in which all object logs will be saved"
+hparam_dict[key]["help"] = help_str
+
+key = "experiment_name"
+hparam_dict[key] = {"type": str, "default": ""}
+help_str = "The subdirectory name under object_logging_dir for a particular experiment run. The current datetime is prepended to this value to compose the full subdirectory name."
 hparam_dict[key]["help"] = help_str
 
 key = "initial_memories_count"


### PR DESCRIPTION
Instead of replacing the object_logging dir with the most recent run each time, we know store all experiment runs in a single base directory. A new subdir is created per experiment run, named after the datetime and an optional experiment name.

The next PR addresses the required changes for Sibyl. As is, this change does not break Sibyl. It just changes which dir is provided as the --log_dir flag value when using Sibyl.