### PR TITLE
Update Sibyl to handle log in subdirectories

### DIFF
--- a/bridger/qfunctions_test.py
+++ b/bridger/qfunctions_test.py
@@ -1,8 +1,13 @@
 """Tests for Q-learning modules"""
+
 import unittest
 
+from typing import NamedTuple
+
+from parameterized import parameterized
+
 import torch
-import bridger.qfunctions as qfunctions
+from bridger import builder_trainer, hash_utils, qfunctions
 
 
 class QFunctionsTest(unittest.TestCase):
@@ -25,6 +30,250 @@ class QFunctionsTest(unittest.TestCase):
         )
         one_hot = qfunctions.encode_enum_state_to_channels(index_tensor, 3)
         self.assertTrue(torch.equal(one_hot, expected_tensor))
+
+
+_ENV_WIDTH = 4
+_NUM_ACTIONS = 4
+_ENV_NAME = "gym_bridges.envs:Bridges-v0"
+_ENV = builder_trainer.make_env(
+    name=_ENV_NAME, width=_ENV_WIDTH, force_standard_config=True
+)
+_BRICK_COUNT = 3
+
+
+class QAndTargetValues(NamedTuple):
+    q_value_0: torch.Tensor
+    target_value_0: torch.Tensor
+    q_value_1: torch.Tensor
+    target_value_1: torch.Tensor
+    q_value_2: torch.Tensor
+    target_value_2: torch.Tensor
+
+
+class QManagerTest(unittest.TestCase):
+    def _get_q_and_target_values(
+        self, q_manager: qfunctions.QManager
+    ) -> QAndTargetValues:
+        x = torch.Tensor(_ENV.reset())
+
+        q_value_0 = q_manager.q(x)
+        target_value_0 = q_manager.target(x)
+
+        # The q and target evaluate the same to start.
+        self.assertTrue(torch.all(q_value_0 == target_value_0))
+
+        q_params = q_manager.q.state_dict()
+
+        # We must access the entries for x explicitly in the tabular
+        # case. Manipulating any weights is sufficient in the neural
+        # network case. The x_hashed value relies on implementation
+        # details for creating keys from both TabularQManager and
+        # ParameterDict. This is suboptimal but was practical.
+        x_hashed = f"_q.{str(hash_utils.hash_tensor(x.int()))}"
+        if x_hashed in q_params:
+            params_key = x_hashed
+        else:
+            params_key = next(iter(q_params))
+
+        q_params[params_key] *= 2
+        q_manager.q.load_state_dict(q_params)
+
+        q_value_1 = q_manager.q(x)
+        target_value_1 = q_manager.target(x)
+
+        q_manager.update_target()
+        q_value_2 = q_manager.q(x)
+        target_value_2 = q_manager.target(x)
+
+        # Calling update_target never affects q itself.
+        self.assertTrue(torch.all(q_value_1 == q_value_2))
+
+        return QAndTargetValues(
+            q_value_0=q_value_0,
+            target_value_0=target_value_0,
+            q_value_1=q_value_1,
+            target_value_1=target_value_1,
+            q_value_2=q_value_2,
+            target_value_2=target_value_2,
+        )
+
+    @parameterized.expand(
+        [
+            (
+                "CNNQManager",
+                qfunctions.CNNQManager(
+                    image_height=_ENV.shape[0],
+                    image_width=_ENV.shape[1],
+                    num_actions=_NUM_ACTIONS,
+                    tau=0,
+                ),
+            ),
+            (
+                "TabularQManager",
+                qfunctions.TabularQManager(
+                    env=_ENV,
+                    brick_count=_BRICK_COUNT,
+                    tau=0,
+                ),
+            ),
+        ]
+    )
+    def test_tau_0(self, name: str, q_manager: qfunctions.QManager):
+        values = self._get_q_and_target_values(q_manager)
+
+        # The q value changes, but the target has not been updated yet.
+        self.assertFalse(torch.all(values.q_value_0 == values.q_value_1))
+        self.assertTrue(torch.all(values.target_value_0 == values.target_value_1))
+
+        # With tau as 0, the target is unchanged after update_target.
+        self.assertTrue(torch.all(values.target_value_1 == values.target_value_2))
+
+    @parameterized.expand(
+        [
+            (
+                "CNNQManager",
+                qfunctions.CNNQManager(
+                    image_height=_ENV.shape[0],
+                    image_width=_ENV.shape[1],
+                    num_actions=_NUM_ACTIONS,
+                    tau=1,
+                ),
+            ),
+            (
+                "TabularQManager",
+                qfunctions.TabularQManager(
+                    env=_ENV,
+                    brick_count=_BRICK_COUNT,
+                    tau=1,
+                ),
+            ),
+        ]
+    )
+    def test_tau_1(self, name: str, q_manager: qfunctions.QManager):
+        values = self._get_q_and_target_values(q_manager)
+
+        # The q value changes, but the target has not been updated yet.
+        self.assertFalse(torch.all(values.q_value_0 == values.q_value_1))
+        self.assertTrue(torch.all(values.target_value_0 == values.target_value_1))
+
+        # With tau as 1, the target now matches q after update_target.
+        self.assertTrue(torch.all(values.q_value_2 == values.target_value_2))
+
+    @parameterized.expand(
+        [
+            (
+                "CNNQManager",
+                qfunctions.CNNQManager(
+                    image_height=_ENV.shape[0],
+                    image_width=_ENV.shape[1],
+                    num_actions=_NUM_ACTIONS,
+                    tau=0.7,
+                ),
+            ),
+            (
+                "TabularQManager",
+                qfunctions.TabularQManager(
+                    env=_ENV,
+                    brick_count=_BRICK_COUNT,
+                    tau=0.7,
+                ),
+            ),
+        ]
+    )
+    def test_tau_intermediate(self, name: str, q_manager: qfunctions.QManager):
+        values = self._get_q_and_target_values(q_manager)
+
+        # The q value changes, but the target has not been updated yet.
+        self.assertFalse(torch.all(values.q_value_0 == values.q_value_1))
+        self.assertTrue(torch.all(values.target_value_0 == values.target_value_1))
+
+        # With tau as .7, the target has changed and also does not
+        # match q after update_target.
+        self.assertFalse(torch.all(values.target_value_1 == values.target_value_2))
+        self.assertFalse(torch.all(values.q_value_2 == values.target_value_2))
+
+    @parameterized.expand(
+        [
+            (
+                "CNNQManager",
+                qfunctions.CNNQManager(
+                    image_height=_ENV.shape[0],
+                    image_width=_ENV.shape[1],
+                    num_actions=_NUM_ACTIONS,
+                    tau=None,
+                ),
+            ),
+            (
+                "TabularQManager",
+                qfunctions.TabularQManager(
+                    env=_ENV,
+                    brick_count=_BRICK_COUNT,
+                    tau=None,
+                ),
+            ),
+        ]
+    )
+    def test_tau_none(self, name: str, q_manager: qfunctions.QManager):
+        values = self._get_q_and_target_values(q_manager)
+
+        # The q value changes and target evaluates the same network.
+        self.assertFalse(torch.all(values.q_value_0 == values.q_value_1))
+        self.assertFalse(torch.all(values.target_value_0 == values.target_value_1))
+        self.assertTrue(torch.all(values.q_value_1 == values.target_value_1))
+
+        # With tau as None, update_target does not do anything.
+        self.assertTrue(torch.all(values.target_value_1 == values.target_value_2))
+        self.assertTrue(torch.all(values.q_value_2 == values.target_value_2))
+
+    @parameterized.expand(
+        [
+            (
+                "CNNQ",
+                qfunctions.CNNQ(
+                    image_height=_ENV.shape[0],
+                    image_width=_ENV.shape[1],
+                    num_actions=_NUM_ACTIONS,
+                ),
+            ),
+            (
+                "TabularQ",
+                qfunctions.TabularQ(
+                    env=_ENV,
+                    brick_count=_BRICK_COUNT,
+                ),
+            ),
+        ]
+    )
+    def test_forward(self, name: str, q: torch.nn.Module):
+        q = qfunctions.TabularQ(env=_ENV, brick_count=_BRICK_COUNT)
+
+        x = torch.Tensor(_ENV.reset())
+
+        value_0 = q(x)
+        self.assertEqual(value_0.shape, (_ENV_WIDTH,))
+
+        value_1 = q(x)
+        self.assertTrue(torch.all(value_0 == value_1))
+        self.assertIsNot(value_0, value_1)
+
+        x_batch = x[None, :]
+
+        batch_value_0 = q(x_batch)
+        self.assertEqual(
+            batch_value_0.shape,
+            (
+                1,
+                _ENV_WIDTH,
+            ),
+        )
+
+        batch_value_1 = q(x_batch)
+        self.assertTrue(torch.all(batch_value_0 == batch_value_1))
+        self.assertIsNot(batch_value_0, batch_value_1)
+        self.assertIsNot(batch_value_0[0], batch_value_1[0])
+
+        self.assertTrue(torch.all(batch_value_0[0] == value_0))
+        self.assertIsNot(batch_value_0[0], batch_value_0)
 
 
 if __name__ == "__main__":

--- a/tools/web/static/css/common.css
+++ b/tools/web/static/css/common.css
@@ -94,3 +94,23 @@ body {
 #experiment-name {
     width: 500px;
 }
+
+.message-banner {
+    padding: 1px;
+    font-size: 18px;
+    font-weight: bold;
+    position: fixed;
+    width: 100%;
+}
+
+#loading {
+    background-color: green;
+}
+
+#load-error {
+    background-color: red;
+}
+
+.hidden {
+    display: none;
+}

--- a/tools/web/static/js/action_inversion.js
+++ b/tools/web/static/js/action_inversion.js
@@ -73,6 +73,9 @@ function update_plots() {
     let start_batch_idx = $("#start-batch-idx").val();
     let end_batch_idx = $("#end-batch-idx").val();
 
+    remove_load_error_indicator();
+    add_loading_indicator();
+
     $.get(`${_ROOT_URL}action_inversion_plot_data`,
 	  {
 	      "experiment_name" : experiment_name,
@@ -82,12 +85,20 @@ function update_plots() {
 	  function(data, response) {
 	      render_action_inversion_plot(data);
 	      $("#current-experiment-name").html(experiment_name);
+    }).fail(function() {
+	add_load_error_indicator();
+    }).always(function() {
+	remove_loading_indicator();
     });    
 }
 
 function update_batch_reports() {
     let experiment_name = $("#experiment-name").val();
     let batch_idx = $("#view-batch-reports-batch-idx").val();
+
+    remove_load_error_indicator();
+    add_loading_indicator();
+
     $.get(`${_ROOT_URL}action_inversion_batch_reports`,
 	  {
 	      "experiment_name" : experiment_name,
@@ -96,6 +107,10 @@ function update_batch_reports() {
 	  function(data, response) {
 	      create_batch_report_div_structure(data.length);
 	      render_batch_reports(data);
+    }).fail(function() {
+	      add_load_error_indicator();
+    }).always(function() {
+	remove_loading_indicator();
     });    
 }
 

--- a/tools/web/static/js/common.js
+++ b/tools/web/static/js/common.js
@@ -80,3 +80,19 @@ function render_array_2d(data, canvas_id, top_row_half_block_positions=null, top
     }
 
 }
+
+function add_loading_indicator() {
+    $("#loading").removeClass("hidden");
+}
+
+function remove_loading_indicator() {
+    $("#loading").addClass("hidden");
+}
+
+function add_load_error_indicator() {
+    $("#load-error").removeClass("hidden");
+}
+
+function remove_load_error_indicator() {
+    $("#load-error").addClass("hidden");
+}

--- a/tools/web/static/js/training_history.js
+++ b/tools/web/static/js/training_history.js
@@ -83,6 +83,9 @@ function update_plots() {
     let max_points_per_series = $("#max-points-per-series").val();
     let number_of_states = $("#number-of-states").val();
 
+    remove_load_error_indicator();
+    add_loading_indicator();
+
     $.get(`${_ROOT_URL}training_history_plot_data`,
 	  {
 	      "experiment_name" : experiment_name,
@@ -95,6 +98,11 @@ function update_plots() {
 	      _DATA = data;
 	      render_plots();
 	      $("#current-experiment-name").html(experiment_name);
+
+    }).fail(function() {
+	add_load_error_indicator();
+    }).always(function() {
+	remove_loading_indicator();
     });    
 }
 
@@ -213,3 +221,4 @@ function zoom_default_charts() {
     $(".plot-holder-metric").addClass("plot-holder-metric-default-width");
     $(".plot-holder-metric").removeClass("plot-holder-metric-full-width");
 }
+

--- a/tools/web/templates/action_inversion.html
+++ b/tools/web/templates/action_inversion.html
@@ -18,6 +18,8 @@
   </head>
   <body>
 
+    <div id="loading" class="message-banner hidden">Loading...</div>
+    <div id="load-error" class="message-banner hidden">Load Error</div>
     <div id="welcome">Action Inversion Analysis</div>
     <div id="current-experiment-name-holder"><div id="current-experiment-name-label">Now Showing </div><div id="current-experiment-name"></div></div>
 

--- a/tools/web/templates/training_history.html
+++ b/tools/web/templates/training_history.html
@@ -17,7 +17,8 @@
     <title>Sibyl: Training History Viewer</title>
   </head>
   <body>
-
+    <div id="loading" class="message-banner hidden">Loading...</div>
+    <div id="load-error" class="message-banner hidden">Load Error</div>
     <div id="welcome">Training History Viewer</div>
     <div id="current-experiment-name-holder"><div id="current-experiment-name-label">Now Showing </div><div id="current-experiment-name"></div></div>
 


### PR DESCRIPTION
Updating Sibyl to support logs in subdirectories.

Specifically:
* Update the object log cache to use the data_key and experiment_name as the cache key
* Update Sibyl to list subdirectories and have a drop-down to select the experiment of choice
