### PR TITLE
Add loading indicator

### DIFF
--- a/tools/web/static/css/common.css
+++ b/tools/web/static/css/common.css
@@ -68,3 +68,22 @@ body {
     background-color: lightgray;
 }
 
+.message-banner {
+    padding: 1px;
+    font-size: 18px;
+    font-weight: bold;
+    position: fixed;
+    width: 100%;
+}
+
+#loading {
+    background-color: green;
+}
+
+#load-error {
+    background-color: red;
+}
+
+.hidden {
+    display: none;
+}

--- a/tools/web/static/js/action_inversion.js
+++ b/tools/web/static/js/action_inversion.js
@@ -72,16 +72,31 @@ function update_plots() {
     let start_batch_idx = $("#start-batch-idx").val();
     let end_batch_idx = $("#end-batch-idx").val();
 
+    remove_load_error_indicator();
+    add_loading_indicator();
+
     $.get(`${_ROOT_URL}action_inversion_plot_data`, { "start_batch_idx": start_batch_idx, "end_batch_idx" : end_batch_idx}, function(data, response) {
 	render_action_inversion_plot(data);
-    });    
+    }).fail(function() {
+	add_load_error_indicator();
+    }).always(function() {
+	remove_loading_indicator();
+    });
 }
 
 function update_batch_reports() {
     let batch_idx = $("#view-batch-reports-batch-idx").val();
+
+    remove_load_error_indicator();
+    add_loading_indicator();
+
     $.get(`${_ROOT_URL}action_inversion_batch_reports`, { "batch_idx": batch_idx}, function(data, response) {
 	create_batch_report_div_structure(data.length);
 	render_batch_reports(data);
+    }).fail(function() {
+	add_load_error_indicator();
+    }).always(function() {
+	remove_loading_indicator();
     });    
 }
 

--- a/tools/web/static/js/common.js
+++ b/tools/web/static/js/common.js
@@ -80,3 +80,19 @@ function render_array_2d(data, canvas_id, top_row_half_block_positions=null, top
     }
 
 }
+
+function add_loading_indicator() {
+    $("#loading").removeClass("hidden");
+}
+
+function remove_loading_indicator() {
+    $("#loading").addClass("hidden");
+}
+
+function add_load_error_indicator() {
+    $("#load-error").removeClass("hidden");
+}
+
+function remove_load_error_indicator() {
+    $("#load-error").addClass("hidden");
+}

--- a/tools/web/static/js/training_history.js
+++ b/tools/web/static/js/training_history.js
@@ -82,9 +82,16 @@ function update_plots() {
     let max_points_per_series = $("#max-points-per-series").val();
     let number_of_states = $("#number-of-states").val();
 
+    remove_load_error_indicator();
+    add_loading_indicator();
+
     $.get(`${_ROOT_URL}training_history_plot_data`, { "start_batch_idx": start_batch_idx, "end_batch_idx" : end_batch_idx, "max_points_per_series" : max_points_per_series, "number_of_states" : number_of_states}, function(data, response) {
 	_DATA = data;
 	render_plots();
+    }).fail(function() {
+	add_load_error_indicator();
+    }).always(function() {
+	remove_loading_indicator();
     });    
 }
 
@@ -203,3 +210,4 @@ function zoom_default_charts() {
     $(".plot-holder-metric").addClass("plot-holder-metric-default-width");
     $(".plot-holder-metric").removeClass("plot-holder-metric-full-width");
 }
+

--- a/tools/web/templates/action_inversion.html
+++ b/tools/web/templates/action_inversion.html
@@ -18,6 +18,8 @@
   </head>
   <body>
 
+    <div id="loading" class="message-banner hidden">Loading...</div>
+    <div id="load-error" class="message-banner hidden">Load Error</div>
     <div id="welcome">Action Inversion Analysis</div>
 
     <div class="interactive-tools">

--- a/tools/web/templates/training_history.html
+++ b/tools/web/templates/training_history.html
@@ -17,7 +17,8 @@
     <title>Sibyl: Training History Viewer</title>
   </head>
   <body>
-
+    <div id="loading" class="message-banner hidden">Loading...</div>
+    <div id="load-error" class="message-banner hidden">Load Error</div>
     <div id="welcome">Training History Viewer</div>
 
     <div class="interactive-tools">


### PR DESCRIPTION
Adds a green bar to the top of the screen to indicate when data is loading and a red one when there's a load error.

Sometimes Sibyl takes time to load all the data for a request and this makes it clear to the user when the plots are updated per request. We use absolute positioning to avoid shifting the page up and down.

The load error indicator requires user investigation in the server log.