### PR TITLE
Align logging dir naming

### DIFF
--- a/bin/bridge_builder.py
+++ b/bin/bridge_builder.py
@@ -109,7 +109,9 @@ def run():
             # we only need a single batch.
             limit_val_batches=1,
             logger=TensorBoardLogger(
-                save_dir=hparams.checkpoint_model_dir, name=full_experiment_name
+                save_dir=hparams.checkpoint_model_dir,
+                name=full_experiment_name,
+                version="",
             ),
             max_steps=hparams.max_training_batches,
             callbacks=callbacks,


### PR DESCRIPTION
The lightning logs and object logging now use the same experiment run naming mechanism so we can link TensorBoard logs and checkpoints with object logging.

We currently don't use the "version_" feature of TensorBoardLogging since each run has a unique datetime prefixed name.