### PR TITLE
Add state visualization to replay buffer state histogram

### DIFF
--- a/tools/web/sibyl.py
+++ b/tools/web/sibyl.py
@@ -163,10 +163,17 @@ def replay_buffer_state_counts_plot_data():
         data_key=object_log_cache.TRAINING_HISTORY_DATABASE_KEY,
     )
 
+    # State visits are sorted by most visited to least visited.
+    replay_buffer_states_by_visit_count = [
+        visit_entry.state.tolist()
+        for visit_entry in training_history_database.get_states_by_visit_count()
+    ]
+
     (
         _,
         replay_buffer_state_counts_by_batch,
     ) = training_history_database.get_replay_buffer_state_counts()
+
     # Sum the replay buffer_state_counts.
     total_replay_buffer_state_counts = Counter()
     for batch_replay_buffer_state_counts in replay_buffer_state_counts_by_batch:
@@ -176,6 +183,7 @@ def replay_buffer_state_counts_plot_data():
     print(f"Sibyl replay buffer state counts took {end-start} ms.")
     return {
         "total_replay_buffer_state_counts": total_replay_buffer_state_counts,
+        "replay_buffer_states_by_visit_count": replay_buffer_states_by_visit_count,
     }
 
 

--- a/tools/web/static/css/replay_buffer_state_counts.css
+++ b/tools/web/static/css/replay_buffer_state_counts.css
@@ -1,0 +1,6 @@
+.plot-hover-canvas {
+  float: right;
+  position: absolute;
+  top: 10;
+  right: 10;
+}

--- a/tools/web/static/js/replay_buffer_state_counts.js
+++ b/tools/web/static/js/replay_buffer_state_counts.js
@@ -54,6 +54,15 @@ let _CHART_OPTIONS_TEMPLATE = {
   },
 };
 
+function render_state_plot(state_index, data) {
+  let canvas_id = `state-plot-state-canvas-${state_index}`;
+  let state_plot_html = `<div class="state-plot-info">Observed State</div>`;
+  state_plot_html += `<div id="state-plot-state-${state_index}" class="state-plot-state"><canvas id="${canvas_id}" class="plot-hover-canvas"></canvas></div>`;
+  $(`#state-holder`).html(state_plot_html);
+
+  render_array_2d(data[state_index], canvas_id);
+}
+
 function update_plots() {
   let experiment_name = $("#experiment-name").val();
 
@@ -70,19 +79,22 @@ function update_plots() {
       render_plots();
       update_url_params();
       $("#current-experiment-name").html(experiment_name);
-    }).fail(function() {
-	add_load_error_indicator();
-    }).always(function() {
-	remove_loading_indicator();
-    });    
+    }
+  )
+    .fail(function () {
+      add_load_error_indicator();
+    })
+    .always(function () {
+      remove_loading_indicator();
+    });
 }
 
 function update_url_params() {
-  let url_param_updates = {'experiment_name' : $("#experiment-name").val() };
-  update_url(url_param_updates);    
+  let url_param_updates = { experiment_name: $("#experiment-name").val() };
+  update_url(url_param_updates);
 }
 
-function render_plots() {   
+function render_plots() {
   // Grab the data from the global _DATA object.
   if (_DATA == null) {
     return;
@@ -90,6 +102,8 @@ function render_plots() {
 
   const total_replay_buffer_state_counts =
     _DATA["total_replay_buffer_state_counts"];
+  const replay_buffer_states_by_visit_count =
+    _DATA["replay_buffer_states_by_visit_count"];
 
   let data = [];
 
@@ -115,9 +129,13 @@ function render_plots() {
     if (!items.length) {
       return "";
     }
-    const item = items[0];
-    const state_id = item.parsed.x;
+    let item = items[0];
+    let state_id = item.parsed.x;
+
+    render_state_plot(state_id, replay_buffer_states_by_visit_count);
+
     return `State id: ${state_id}`;
   };
+
   new Chart($("#histogram"), chart_options);
 }

--- a/tools/web/static/js/training_history.js
+++ b/tools/web/static/js/training_history.js
@@ -1,235 +1,263 @@
-let _MAX_RENDER_COUNT = 20
+let _MAX_RENDER_COUNT = 20;
 
 let _CHART_OPTIONS_TEMPLATE = {
-    scales: {
-	x: {
-	    title: {
-		display: true,
-		color: "#FFFFFF",
-		font: {
-                    size: 12,
-		}
-            },
-	    ticks: {
-		color: "#FFFFFF",
-		font: {
-                    size: 12,
-		}
-	    }
-	},
-        y: {
-	    ticks: {
-		color: "#FFFFFF",
-		font: {
-                    size: 12,
-		}
-	    },
+  scales: {
+    x: {
+      title: {
+        display: true,
+        color: "#FFFFFF",
+        font: {
+          size: 12,
         },
+      },
+      ticks: {
+        color: "#FFFFFF",
+        font: {
+          size: 12,
+        },
+      },
     },
-    plugins: {
-	title: {
-	    color: "#FFFFFF",
-	    display: true,
-	    font: {
-                size: 16,
-	    }
-	},
-	legend: {
-	    align: 'end',
-	    labels: {
-		boxWidth: 8,
-		color: "#FFFFFF",
-	    }
-	},
+    y: {
+      ticks: {
+        color: "#FFFFFF",
+        font: {
+          size: 12,
+        },
+      },
     },
-    elements: {
-	point: {
-	    pointStyle: 'cross',
-	    radius: 1,
-	    hoverRadius: 10,
-	},
-	line: {
-	    borderWidth: 1,
-	}
+  },
+  plugins: {
+    title: {
+      color: "#FFFFFF",
+      display: true,
+      font: {
+        size: 16,
+      },
     },
+    legend: {
+      align: "end",
+      labels: {
+        boxWidth: 8,
+        color: "#FFFFFF",
+      },
+    },
+  },
+  elements: {
+    point: {
+      pointStyle: "cross",
+      radius: 1,
+      hoverRadius: 10,
+    },
+    line: {
+      borderWidth: 1,
+    },
+  },
 };
 
 // TODO(lyric): Create a better color list.
 let _COLORS = [
-    'rgba(255, 0, 0, 1)',
-    'rgba(0, 255, 0, 1)',
-    'rgba(0, 0, 255, 1)',
-    'rgba(255, 255, 0, 1)',
-    'rgba(0, 255, 255, 1)',
-    'rgba(255, 0, 255, 1)',
-    'rgba(127, 0, 0, 1)',
-    'rgba(0, 127, 0, 1)',
-    'rgba(0, 0, 127, 1)',
-    'rgba(127, 127, 0, 1)',
-    'rgba(0, 127, 127, 1)',
-    'rgba(127, 0, 127, 1)',
-]
+  "rgba(255, 0, 0, 1)",
+  "rgba(0, 255, 0, 1)",
+  "rgba(0, 0, 255, 1)",
+  "rgba(255, 255, 0, 1)",
+  "rgba(0, 255, 255, 1)",
+  "rgba(255, 0, 255, 1)",
+  "rgba(127, 0, 0, 1)",
+  "rgba(0, 127, 0, 1)",
+  "rgba(0, 0, 127, 1)",
+  "rgba(127, 127, 0, 1)",
+  "rgba(0, 127, 127, 1)",
+  "rgba(127, 0, 127, 1)",
+];
 
 let _DATA = null;
 
 let _STATE_FILTER = null;
 
 function update_plots() {
-    let plot_params = get_plot_params();
+  let plot_params = get_plot_params();
 
-    remove_load_error_indicator();
-    add_loading_indicator();
+  remove_load_error_indicator();
+  add_loading_indicator();
 
-    $.get(`${_ROOT_URL}training_history_plot_data`,
-	  plot_params,
-	  function(data, response) {
-	      _DATA = data;
-	      render_plots();
-	      $("#current-experiment-name").html(plot_params['experiment_name']);
-    }).fail(function() {
-	add_load_error_indicator();
-    }).always(function() {
-	remove_loading_indicator();
-    });    
+  $.get(
+    `${_ROOT_URL}training_history_plot_data`,
+    plot_params,
+    function (data, response) {
+      _DATA = data;
+      render_plots();
+      $("#current-experiment-name").html(plot_params["experiment_name"]);
+    }
+  )
+    .fail(function () {
+      add_load_error_indicator();
+    })
+    .always(function () {
+      remove_loading_indicator();
+    });
 }
 
 function update_state_filter() {
-    _STATE_FILTER = new Function('state', $("#state-filter-function-body").val());
-    render_plots();
+  _STATE_FILTER = new Function("state", $("#state-filter-function-body").val());
+  render_plots();
 }
 
 function get_plot_params() {
-    let experiment_name = $("#experiment-name").val();
-    let start_batch_idx = $("#start-batch-idx").val();
-    let end_batch_idx = $("#end-batch-idx").val();
-    let max_points_per_series = $("#max-points-per-series").val();
-    let number_of_states = $("#number-of-states").val();
+  let experiment_name = $("#experiment-name").val();
+  let start_batch_idx = $("#start-batch-idx").val();
+  let end_batch_idx = $("#end-batch-idx").val();
+  let max_points_per_series = $("#max-points-per-series").val();
+  let number_of_states = $("#number-of-states").val();
 
-    return {
-	"experiment_name" : experiment_name,
-	"start_batch_idx" : start_batch_idx,
-	"end_batch_idx" : end_batch_idx,
-	"max_points_per_series" : max_points_per_series,
-	"number_of_states" : number_of_states,
-    }
+  return {
+    experiment_name: experiment_name,
+    start_batch_idx: start_batch_idx,
+    end_batch_idx: end_batch_idx,
+    max_points_per_series: max_points_per_series,
+    number_of_states: number_of_states,
+  };
 }
 
 function update_url_params() {
-    let url_param_updates = get_plot_params();
-    url_param_updates["state_filter_function_body"] = $("#state-filter-function-body").val();
-    update_url(url_param_updates);
+  let url_param_updates = get_plot_params();
+  url_param_updates["state_filter_function_body"] = $(
+    "#state-filter-function-body"
+  ).val();
+  update_url(url_param_updates);
 }
 
 function render_plots() {
-    update_url_params();
-    
-    if (_DATA == null) {
-	return;
-    }
-    
-    let plot_data = _DATA['plot_data'];
-    if (plot_data.length == 0) {
-	return;
+  update_url_params();
+
+  if (_DATA == null) {
+    return;
+  }
+
+  let plot_data = _DATA["plot_data"];
+  if (plot_data.length == 0) {
+    return;
+  }
+
+  let state_index_list = [];
+  let render_count = Math.min(plot_data.length, _MAX_RENDER_COUNT);
+
+  for (let state_index = 0; state_index < plot_data.length; state_index++) {
+    if (_STATE_FILTER(plot_data[state_index]["state"])) {
+      state_index_list.push(state_index);
     }
 
-    let state_index_list = []
-    let render_count = Math.min(plot_data.length, _MAX_RENDER_COUNT)
-
-    for (let state_index = 0; state_index < plot_data.length; state_index++) {
-	if (_STATE_FILTER(plot_data[state_index]['state'])) {
-	    state_index_list.push(state_index);
-	}
-
-	if (state_index_list.length == render_count) {
-	    break;
-	}
+    if (state_index_list.length == render_count) {
+      break;
     }
-    
-    create_plot_div_structure(state_index_list.length, plot_data[0]['metrics'].length);
+  }
 
-    for (let i = 0; i < state_index_list.length; i++) {
-	state_index = state_index_list[i]
-	let row_data = plot_data[state_index];
-	render_state_plot(i, row_data);
-	for (let metric_index = 0; metric_index < row_data['metrics'].length; metric_index++) {
-	    let metric_entry = row_data['metrics'][metric_index];
-	    render_training_plot(metric_entry['metric'], i, metric_index, _DATA['labels'], metric_entry['series_data'], metric_entry['series_labels']);
-	}
+  create_plot_div_structure(
+    state_index_list.length,
+    plot_data[0]["metrics"].length
+  );
+
+  for (let i = 0; i < state_index_list.length; i++) {
+    state_index = state_index_list[i];
+    let row_data = plot_data[state_index];
+    render_state_plot(i, row_data);
+    for (
+      let metric_index = 0;
+      metric_index < row_data["metrics"].length;
+      metric_index++
+    ) {
+      let metric_entry = row_data["metrics"][metric_index];
+      render_training_plot(
+        metric_entry["metric"],
+        i,
+        metric_index,
+        _DATA["labels"],
+        metric_entry["series_data"],
+        metric_entry["series_labels"]
+      );
     }
+  }
 }
 
 function create_plot_div_structure(state_count, metric_count) {
-    // Creates the plot-related div structure for all the rows of
-    // data.
+  // Creates the plot-related div structure for all the rows of
+  // data.
 
-    let plot_divs = "";
-    for (let i = 0; i < state_count; i++) {
-	plot_divs += `<div class="plots-row plots-row-background-${i % 2}">`;
-	plot_divs += `<div id="plot-holder-${i}-state" class="plot-holder-state"></div>`;
-	for (let j = 0; j < metric_count; j++) {
-	    plot_divs += `<div id="plot-holder-${i}-metric-${j}" class="plot-holder-metric plot-holder-metric-default-width"></div>`;
-	}
-	plot_divs += '</div>';
+  let plot_divs = "";
+  for (let i = 0; i < state_count; i++) {
+    plot_divs += `<div class="plots-row plots-row-background-${i % 2}">`;
+    plot_divs += `<div id="plot-holder-${i}-state" class="plot-holder-state"></div>`;
+    for (let j = 0; j < metric_count; j++) {
+      plot_divs += `<div id="plot-holder-${i}-metric-${j}" class="plot-holder-metric plot-holder-metric-default-width"></div>`;
     }
-    $("#plots-holder").html(plot_divs)
+    plot_divs += "</div>";
+  }
+  $("#plots-holder").html(plot_divs);
 }
 
-function render_training_plot(metric, state_index, metric_index, labels, series_data, series_labels) {
-    let canvas_id = `plot-canvas-${state_index}-metric-${metric_index}`;
-    training_plot_html = `<canvas id="${canvas_id}" class="plot-canvas"></canvas>`;
-    $(`#plot-holder-${state_index}-metric-${metric_index}`).html(training_plot_html);
-    
-    let datasets = [];
-    for (let i = 0; i < series_data.length; i++) {
-	let dataset = {};
-	dataset['data'] = series_data[i];
-	dataset['label'] = series_labels[i];
-	dataset['borderColor'] = _COLORS[i];
-	dataset['backgroundColor'] = _COLORS[i];
-	datasets.push(dataset);
-    }
-    
-    chart_options = structuredClone(_CHART_OPTIONS_TEMPLATE);
-    chart_options['plugins']['title']['text'] = metric;
-    chart_options['scales']['x']['title']['text'] = 'Batch Index';
-    new Chart($(`#${canvas_id}`), {
-	type: 'line',
-	data: {
-            labels: labels,
-            datasets: datasets
-	},
-	options: chart_options,
-    });    
+function render_training_plot(
+  metric,
+  state_index,
+  metric_index,
+  labels,
+  series_data,
+  series_labels
+) {
+  let canvas_id = `plot-canvas-${state_index}-metric-${metric_index}`;
+  training_plot_html = `<canvas id="${canvas_id}" class="plot-canvas"></canvas>`;
+  $(`#plot-holder-${state_index}-metric-${metric_index}`).html(
+    training_plot_html
+  );
+
+  let datasets = [];
+  for (let i = 0; i < series_data.length; i++) {
+    let dataset = {};
+    dataset["data"] = series_data[i];
+    dataset["label"] = series_labels[i];
+    dataset["borderColor"] = _COLORS[i];
+    dataset["backgroundColor"] = _COLORS[i];
+    datasets.push(dataset);
+  }
+
+  chart_options = structuredClone(_CHART_OPTIONS_TEMPLATE);
+  chart_options["plugins"]["title"]["text"] = metric;
+  chart_options["scales"]["x"]["title"]["text"] = "Batch Index";
+  new Chart($(`#${canvas_id}`), {
+    type: "line",
+    data: {
+      labels: labels,
+      datasets: datasets,
+    },
+    options: chart_options,
+  });
 }
 
 function render_state_plot(state_index, data) {
-    let canvas_id = `state-plot-state-canvas-${state_index}`
-    let state_plot_html = `<div class="state-plot-info">Visits: ${data['visit_count']}</div>`;
-    state_plot_html += `<div id="state-plot-state-${state_index}" class="state-plot-state"><canvas id="${canvas_id}" class="plot-canvas"></canvas></div>`;
-    $(`#plot-holder-${state_index}-state`).html(state_plot_html);
+  let canvas_id = `state-plot-state-canvas-${state_index}`;
+  let state_plot_html = `<div class="state-plot-info">Visits: ${data["visit_count"]}</div>`;
+  state_plot_html += `<div id="state-plot-state-${state_index}" class="state-plot-state"><canvas id="${canvas_id}" class="plot-canvas"></canvas></div>`;
+  $(`#plot-holder-${state_index}-state`).html(state_plot_html);
 
-    render_array_2d(data['state'], canvas_id);
+  render_array_2d(data["state"], canvas_id);
 }
 
 function zoom_in_charts() {
-    $("#zoom-button-full").addClass("button-selected");
-    $("#zoom-button-full").removeClass("button-unselected");
-    
-    $("#zoom-button-default").addClass("button-unselected");
-    $("#zoom-button-default").removeClass("button-selected");
+  $("#zoom-button-full").addClass("button-selected");
+  $("#zoom-button-full").removeClass("button-unselected");
 
-    $(".plot-holder-metric").addClass("plot-holder-metric-full-width");
-    $(".plot-holder-metric").removeClass("plot-holder-metric-default-width");
+  $("#zoom-button-default").addClass("button-unselected");
+  $("#zoom-button-default").removeClass("button-selected");
+
+  $(".plot-holder-metric").addClass("plot-holder-metric-full-width");
+  $(".plot-holder-metric").removeClass("plot-holder-metric-default-width");
 }
 
 function zoom_default_charts() {
-    $("#zoom-button-default").addClass("button-selected");
-    $("#zoom-button-default").removeClass("button-unselected");
+  $("#zoom-button-default").addClass("button-selected");
+  $("#zoom-button-default").removeClass("button-unselected");
 
-    $("#zoom-button-full").addClass("button-unselected");
-    $("#zoom-button-full").removeClass("button-selected");
+  $("#zoom-button-full").addClass("button-unselected");
+  $("#zoom-button-full").removeClass("button-selected");
 
-    $(".plot-holder-metric").addClass("plot-holder-metric-default-width");
-    $(".plot-holder-metric").removeClass("plot-holder-metric-full-width");
+  $(".plot-holder-metric").addClass("plot-holder-metric-default-width");
+  $(".plot-holder-metric").removeClass("plot-holder-metric-full-width");
 }
-

--- a/tools/web/templates/replay_buffer_state_counts.html
+++ b/tools/web/templates/replay_buffer_state_counts.html
@@ -1,4 +1,5 @@
 <script src= {{ url_for('static',filename='js/replay_buffer_state_counts.js') }}></script>
+<link rel= "stylesheet" type= "text/css" href= {{ url_for('static',filename='css/replay_buffer_state_counts.css') }}>
 
 {% extends 'base.html' %}
 
@@ -27,6 +28,7 @@
 
     <div id="plots-holder"></div>
     <div id="histogram-holder" width="700px"></div>
+    <div id="state-holder" width="700px"></div>
 
     <script>
       $( document ).ready(function() {


### PR DESCRIPTION
Adds a small visual of the state in the replay buffer state histogram on hover in the replay buffer state counts page on Sibyl. 

<img width="1552" alt="Screen Shot 2023-07-10 at 11 22 28 PM" src="https://github.com/ldoshi/rome-wasnt-built-in-a-day/assets/37686936/feecbd3b-f353-4cfd-aa86-d33d38d8bbfb">
