### PR TITLE
Fix data loader

### DIFF
--- a/bin/bridge_builder.py
+++ b/bin/bridge_builder.py
@@ -16,10 +16,9 @@
 import datetime
 import os
 
-from pytorch_lightning import Trainer
-from pytorch_lightning.loggers import TensorBoardLogger
-from pytorch_lightning.callbacks import ModelCheckpoint
-from pytorch_lightning.callbacks import EarlyStopping
+from lightning import Trainer
+from lightning.pytorch.loggers import TensorBoardLogger
+from lightning.pytorch.callbacks import EarlyStopping, ModelCheckpoint
 
 from bridger import builder
 from bridger import builder_trainer
@@ -100,7 +99,7 @@ def run():
 
         trainer = Trainer(
             gradient_clip_val=hparams.gradient_clip_val,
-            val_check_interval=hparams.val_check_interval,
+            check_val_every_n_epoch=hparams.val_check_interval,
             # The validation batch size can be adjusted via a config, but
             # we only need a single batch.
             limit_val_batches=1,
@@ -109,7 +108,9 @@ def run():
                 name=full_experiment_name,
                 version="",
             ),
-            max_steps=hparams.max_training_batches,
+            limit_train_batches=1,
+            max_epochs=hparams.max_training_batches,
+            reload_dataloaders_every_n_epochs=1,
             callbacks=callbacks,
         )
 

--- a/bridger/builder_trainer.py
+++ b/bridger/builder_trainer.py
@@ -66,7 +66,6 @@ def make_env(
     name: str,
     width: int,
     force_standard_config: bool,
-    max_valid_brick_count: int | None = None,
     seed: Union[int, float, None] = None,
 ) -> gym.Env:
     """Function that instantiates an instance of the environment with the appropriate arguments.
@@ -75,7 +74,6 @@ def make_env(
         name: name of environment to construct.
         width: width of the bridge_builder environment.
         force_standard_config: whether to only use the standard environment configuration.
-        max_valid_brick_count: the max number of bricks that can be added in the environment.
 
     Returns:
         An instantiated gym environment.
@@ -84,7 +82,6 @@ def make_env(
         name,
         width=width,
         force_standard_config=force_standard_config,
-        max_valid_brick_count=max_valid_brick_count,
         seed=seed,
     )
     return env
@@ -274,7 +271,6 @@ class BridgeBuilderModel(lightning.LightningModule):
             name=self.hparams.env_name,
             width=self.hparams.env_width,
             force_standard_config=self.hparams.env_force_standard_config,
-            max_valid_brick_count=self.hparams.env_max_valid_brick_count,
             seed=torch.rand(1).item(),
         )
         self._validation_env = make_env(

--- a/bridger/builder_trainer_test.py
+++ b/bridger/builder_trainer_test.py
@@ -8,8 +8,8 @@ import numpy as np
 import os
 import shutil
 from parameterized import parameterized
-from pytorch_lightning.callbacks import Callback
-from pytorch_lightning.callbacks import EarlyStopping
+from lightning import Callback
+from lightning.pytorch.callbacks import EarlyStopping
 
 import torch
 

--- a/bridger/callbacks.py
+++ b/bridger/callbacks.py
@@ -1,6 +1,6 @@
 import torch
 
-from pytorch_lightning.callbacks import Callback
+from lightning.pytorch import Callback
 
 from bridger import builder_trainer
 from bridger import builder
@@ -28,7 +28,7 @@ class DemoCallback(Callback):
                 )
             )
 
-        if (batch_idx + 1) % self._frequency == 0:
+        if (model.global_step + 1) % self._frequency == 0:
             with torch.no_grad():
                 build_result = self._builder.build(
                     model.policy, self._max_episode_length

--- a/bridger/debug_worlds.py
+++ b/bridger/debug_worlds.py
@@ -2,8 +2,8 @@
 
 import gym
 
-from pytorch_lightning import Trainer
-from pytorch_lightning.callbacks import Callback
+from lightning import Trainer
+from lightning.pytorch import Callback
 
 from bridger.builder_trainer import BridgeBuilderModel
 

--- a/bridger/replay_buffer_initializers.py
+++ b/bridger/replay_buffer_initializers.py
@@ -41,6 +41,18 @@ def _only_reset_state(
         next_state, reward, done, _ = env.step(action)
         yield state, action, next_state, reward, done
 
+        
+def _single_column(env: gym.Env) -> Generator[tuple[Any, Any, Any, Any, Any], None, None]:
+    state = env.reset()
+    for i in range(10):
+        for action in range(env.nA):
+            env.reset(state)
+            next_state, reward, done, _ = env.step(action)
+            yield state, action, next_state, reward, done
+
+        env.reset(state)
+        state, _, _, _ = env.step(0)  
+        
 
 def _standard_configuration_bridge_states(
     env: gym.Env,
@@ -120,6 +132,7 @@ def _n_bricks(
 
 
 STRATEGY_ONLY_RESET_STATE = "only_reset_state"
+STRATEGY_SINGLE_COLUMN = "single_column"            
 STRATEGY_STANDARD_CONFIGURATION_BRIDGE_STATES = "standard_configuration_bridge_states"
 STRATEGY_2_BRICKS = "2_bricks"
 STRATEGY_4_BRICKS = "4_bricks"
@@ -129,6 +142,7 @@ _INITIALIZE_REPLAY_BUFFER_BATCH_IDX = -1
 
 _STRATEGY_MAP = {
     STRATEGY_ONLY_RESET_STATE: _only_reset_state,
+    STRATEGY_SINGLE_COLUMN: _single_column,
     STRATEGY_STANDARD_CONFIGURATION_BRIDGE_STATES: _standard_configuration_bridge_states,
     STRATEGY_2_BRICKS: functools.partial(_n_bricks, brick_count=2),
     STRATEGY_4_BRICKS: functools.partial(_n_bricks, brick_count=4),

--- a/bridger/test_utils.py
+++ b/bridger/test_utils.py
@@ -10,8 +10,8 @@ from bridger import builder_trainer
 
 from typing import Optional
 
-from pytorch_lightning import Trainer
-from pytorch_lightning.callbacks import Callback
+from lightning import Trainer
+from lightning.pytorch import Callback
 
 TMP_DIR = "tmp/nested_tmp"
 _OBJECT_LOGGING_DIR = "tmp_object_logging_dir"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask==2.2.2
 ipython==8.7.0
 numpy==1.24.0
 pandas==1.5.2
-pytorch-lightning==1.8.6
+lightning=2.2.3
 torch==1.13.1
 protobuf==3.20.1
 Werkzeug==2.2.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Flask==2.2.2
 ipython==8.7.0
 numpy==1.24.0
 pandas==1.5.2
-lightning=2.2.3
+lightning==2.2.3
 torch==1.13.1
 protobuf==3.20.1
 Werkzeug==2.2.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         "gym-bridges>=0.0.1",
         "numpy>=1.18.5",
         "matplotlib>=3.3.2",
-        "pytorch-lightning==1.8.6",
+        "lightning==2.2.3",
         "torch>=1.8.0",
     ],
     # TODO: add metadata kwargs if uploading to PyPI


### PR DESCRIPTION
Upgrade lightning
Change to use epochs as 1 epoch per iteration instead of many batches in a single epoch so that the data loader can be reset each epoch and pick up changes in the replay buffer. python iterators, like in the data loader, are immutable and don't pick changes in the replay buffer so we have never used the replay buffer's new memories so far. 