### PR TITLE
Parallel runner

### DIFF
--- a/tools/experiment_runner.py
+++ b/tools/experiment_runner.py
@@ -67,14 +67,19 @@ def _get_experiment_name(experiment_name_prefix: str, values: Sequence) -> str:
         else experiment_name_suffix
     )
 
-def _executor(execute_fn: Callable[[list[str]], None], experiment_name_prefix: str, args: list[Any], sweep_keys: list[str],iteration_values: list[list[Any]]) -> list[str]:
-    
+
+def _executor(
+    execute_fn: Callable[[list[str]], None],
+    experiment_name_prefix: str,
+    args: list[Any],
+    sweep_keys: list[str],
+    iteration_values: list[list[Any]],
+) -> list[str]:
+
     iteration_args = copy.deepcopy(args)
     assert len(sweep_keys) == len(iteration_values)
     for flag_name, flag_value in zip(sweep_keys, iteration_values):
-        _add_args(
-            args=iteration_args, flag_name=flag_name, flag_value=flag_value
-        )
+        _add_args(args=iteration_args, flag_name=flag_name, flag_value=flag_value)
 
     _add_args(
         args=iteration_args,
@@ -90,7 +95,10 @@ def _executor(execute_fn: Callable[[list[str]], None], experiment_name_prefix: s
 
 
 def run_experiments(
-        config: dict[str, Any], execute_fn: Callable[[list[str]], None], record_fn: Callable[[list[str]], None] | None = None, num_processes: int=1
+    config: dict[str, Any],
+    execute_fn: Callable[[list[str]], None],
+    record_fn: Callable[[list[str]], None] | None = None,
+    num_processes: int = 1,
 ) -> None:
     """Calls execute_fn for argument combinations described in config.
 
@@ -123,15 +131,19 @@ def run_experiments(
     for flag_name in sorted(config):
         flag_value = config[flag_name]
         _add_args(args=args, flag_name=flag_name, flag_value=flag_value)
-        
+
     if sweep_keys:
-        executor_fn = functools.partial(_executor, execute_fn, experiment_name_prefix, args, sweep_keys)
+        executor_fn = functools.partial(
+            _executor, execute_fn, experiment_name_prefix, args, sweep_keys
+        )
         with Pool(num_processes) as pool:
-        # Iterate sweep combinations.
-            for iteration_args in pool.map(executor_fn, itertools.product(*sweep_values)):
+            # Iterate sweep combinations.
+            for iteration_args in pool.map(
+                executor_fn, itertools.product(*sweep_values)
+            ):
                 if record_fn is not None:
                     record_fn(iteration_args)
-            
+
     else:
         if experiment_name_prefix:
             _add_args(
@@ -140,4 +152,3 @@ def run_experiments(
         execute_fn(args)
         if record_fn is not None:
             record_fn(args)
-

--- a/tools/experiment_runner_main.py
+++ b/tools/experiment_runner_main.py
@@ -53,6 +53,12 @@ def main():
         type=str,
         required=True,
     )
+    parser.add_argument(
+        "--num-processes",
+        help="The number of experiments to run in parallel.",
+        type=int,
+        default=1,
+    )
     parsed_args = parser.parse_args()
 
     with open(parsed_args.config) as f:
@@ -62,7 +68,7 @@ def main():
         command = [parsed_args.binary] + args
         subprocess.run(command, check=True)
 
-    experiment_runner.run_experiments(config=config, execute_fn=execute_fn)
+    experiment_runner.run_experiments(config=config, execute_fn=execute_fn, num_processes=parsed_args.num_processes)
 
 
 if __name__ == "__main__":

--- a/tools/experiment_runner_main.py
+++ b/tools/experiment_runner_main.py
@@ -68,7 +68,9 @@ def main():
         command = [parsed_args.binary] + args
         subprocess.run(command, check=True)
 
-    experiment_runner.run_experiments(config=config, execute_fn=execute_fn, num_processes=parsed_args.num_processes)
+    experiment_runner.run_experiments(
+        config=config, execute_fn=execute_fn, num_processes=parsed_args.num_processes
+    )
 
 
 if __name__ == "__main__":

--- a/tools/experiment_runner_test.py
+++ b/tools/experiment_runner_test.py
@@ -1,4 +1,5 @@
 """Tests for experiment_runner."""
+
 import unittest
 
 from typing import Any, Callable
@@ -38,7 +39,7 @@ def _get_value(args: list[str], key: str) -> str:
 def _execute_fn(args: list[str]) -> None:
     return args
 
-    
+
 class ExperimentRunnerTest(unittest.TestCase):
     """Verifies parameter sweeps from configs."""
 
@@ -61,7 +62,9 @@ class ExperimentRunnerTest(unittest.TestCase):
         """Verifies execution args are built correctly."""
 
         config = _load_config(config_filename)
-        experiment_runner.run_experiments(config=config, execute_fn=_execute_fn, record_fn=self.record_fn)
+        experiment_runner.run_experiments(
+            config=config, execute_fn=_execute_fn, record_fn=self.record_fn
+        )
         self.assertEqual(len(self._args), 1)
         self.assertEqual(
             self._args[0],
@@ -80,7 +83,9 @@ class ExperimentRunnerTest(unittest.TestCase):
 
     def test_execution_args_nameless(self):
         config = _load_config(_NAMELESS_CONFIG)
-        experiment_runner.run_experiments(config=config, execute_fn=_execute_fn, record_fn=self.record_fn)
+        experiment_runner.run_experiments(
+            config=config, execute_fn=_execute_fn, record_fn=self.record_fn
+        )
         self.assertEqual(len(self._args), 1)
         self.assertEqual(
             self._args[0], ["--env-width", "3", "--val-check-interval", "13"]
@@ -94,7 +99,9 @@ class ExperimentRunnerTest(unittest.TestCase):
     )
     def test_two_sweeps(self, name: str, config: str, experiment_name_prefix: str):
         config = _load_config(config)
-        experiment_runner.run_experiments(config=config, execute_fn=_execute_fn, record_fn=self.record_fn)
+        experiment_runner.run_experiments(
+            config=config, execute_fn=_execute_fn, record_fn=self.record_fn
+        )
         self.assertEqual(len(self._args), 12)
         expected_value_tuples = itertools.product(
             ["--debug", "--no-debug"],


### PR DESCRIPTION
Run multiple experiments in parallel.

Record fn exists as a strange artifact to ease testing because the function passed to map() in multiprocessing needs to be pickle-able and hence module level.