### PR TITLE
Fix bug with tabular q manager

### DIFF
--- a/bridger/qfunctions.py
+++ b/bridger/qfunctions.py
@@ -279,8 +279,6 @@ class TabularQ(torch.nn.Module):
             ):
                 state_hashes.update(hashes)
         for state_hash in state_hashes:
-            # Remove decimals from string representation of state hashes. torch.nn.Parameter does not support `.` in Parameter name.
-            state_hash = state_hash.replace(".0", "")
             self._q[state_hash] = torch.nn.Parameter(
                 torch.rand(env.nA, requires_grad=True)
             )
@@ -293,7 +291,7 @@ class TabularQ(torch.nn.Module):
         and tensors consistent.
         """
 
-        return str(self._hash_fn(x))
+        return str(self._hash_fn(x.int()))
 
     def forward(self, x):
         # The tensor must be converted to int to match the state hash

--- a/bridger/qfunctions.py
+++ b/bridger/qfunctions.py
@@ -272,20 +272,20 @@ class TabularQ(torch.nn.Module):
 
         state_hashes = set()
         state_hashes.add(self._internal_hash(env.reset()))
-
         with multiprocessing.Pool() as pool:
             for hashes in pool.map(
                 _collect_parameters_function,
                 itertools.product(range(env.nA), repeat=initial_brick_count),
             ):
                 state_hashes.update(hashes)
-
         for state_hash in state_hashes:
+            # Remove decimals from string representation of state hashes. torch.nn.Parameter does not support `.` in Parameter name.
+            state_hash = state_hash.replace(".0", "")
             self._q[state_hash] = torch.nn.Parameter(
                 torch.rand(env.nA, requires_grad=True)
             )
 
-    def _internal_hash(self, x) -> str:
+    def _internal_hash(self, x: torch.Tensor) -> str:
         """Hashes states per component requirements.
 
         ParameterDict does not allow non-str as dict keys. The

--- a/bridger/qfunctions_test.py
+++ b/bridger/qfunctions_test.py
@@ -70,6 +70,7 @@ class QManagerTest(unittest.TestCase):
         # details for creating keys from both TabularQManager and
         # ParameterDict. This is suboptimal but was practical.
         x_hashed = f"_q.{str(hash_utils.hash_tensor(x.int()))}"
+
         if x_hashed in q_params:
             params_key = x_hashed
         else:

--- a/tools/experiment_runner.py
+++ b/tools/experiment_runner.py
@@ -73,9 +73,9 @@ def _executor(
     experiment_name_prefix: str,
     args: list[Any],
     sweep_keys: list[str],
-    iteration_values: list[list[Any]],
+    iteration_values: list[Any],
 ) -> list[str]:
-    
+
     iteration_args = copy.deepcopy(args)
     assert len(sweep_keys) == len(iteration_values)
     for flag_name, flag_value in zip(sweep_keys, iteration_values):

--- a/tools/experiment_runner.py
+++ b/tools/experiment_runner.py
@@ -75,7 +75,7 @@ def _executor(
     sweep_keys: list[str],
     iteration_values: list[list[Any]],
 ) -> list[str]:
-
+    
     iteration_args = copy.deepcopy(args)
     assert len(sweep_keys) == len(iteration_values)
     for flag_name, flag_value in zip(sweep_keys, iteration_values):

--- a/tools/experiment_runner_test.py
+++ b/tools/experiment_runner_test.py
@@ -37,7 +37,7 @@ def _get_value(args: list[str], key: str) -> str:
 
 
 def _execute_fn(args: list[str]) -> None:
-    return args
+    return
 
 
 class ExperimentRunnerTest(unittest.TestCase):


### PR DESCRIPTION
torch.nn.Parameter cannot take periods. Currently the state hash string representation of states have decimals, even if you try to round. Modify state hash before passing it to torch.nn.Parameter