### PR TITLE
Async go explore

### DIFF
--- a/bridger/config/training.py
+++ b/bridger/config/training.py
@@ -109,9 +109,9 @@ hparam_dict[key] = {"type": int, "default": 8}
 help_str = "The number of actions to take in an exploration rollout for go-explore."
 hparam_dict[key]["help"] = help_str
 
-key = "go_explore_num_iterations"
+key = "go_explore_num_tasks"
 hparam_dict[key] = {"type": int, "default": 8}
-help_str = "The number of iterations of exploration rollouts for go-explore."
+help_str = "The number of exploration rollout tasks to assign for go-explore. This is effectively an iteration count."
 hparam_dict[key]["help"] = help_str
 
 key = "go_explore_epsilon_1"
@@ -159,9 +159,9 @@ hparam_dict[key] = {"type": int, "default": 2}
 help_str = "The y stride to downsample the state."
 hparam_dict[key]["help"] = help_str
 
-key = "go_explore_num_samples_per_iteration"
-hparam_dict[key] = {"type": int, "default": 1200}
-help_str = "The number of processes to use for rollout."
+key = "go_explore_num_samples_per_worker_task"
+hparam_dict[key] = {"type": int, "default": 10}
+help_str = "The number of samples to send each worker as a task"
 hparam_dict[key]["help"] = help_str
 
 key = "jitter"

--- a/bridger/go_explore_phase_1.py
+++ b/bridger/go_explore_phase_1.py
@@ -28,8 +28,6 @@ RolloutParams = namedtuple(
     ],
 )
 
-_WORK_PER_CHUNK = 10
-
 
 def _count_score(
     v: float, wa: float, pa: float, epsilon_1: float, epsilon_2: float
@@ -369,22 +367,33 @@ def rollout(
     return success_entries, state_sampler_cache_update
 
 
+def rollout_worker(task_queue, result_queue, rollout_func):
+    while True:
+        task = task_queue.get()
+        if task is None:
+            break
+
+        result = rollout_func(*task)
+        result_queue.put(result)
+
 def explore(
     object_logger: ObjectLogManager,
     hparams: Any,
 ) -> set[SuccessEntry]:
-    """
-    Generate success entries by performing exploration in the environment.
+    """Generate success entries by performing exploration in the environment.
 
     Uses multiple processes to collect rollouts and update the state cache.
 
-    This function runs a specified number of iterations, where in each iteration, it samples
-    start states and entries from the cache, generates random seeds for each process, and
-    collects rollouts in parallel using multiprocessing. The collected rollouts are then used
-    to update the cache and accumulate successful entries.
+    This function generates a specified number of tasks to send to
+    rollout workers. For each task, it samples start states and
+    entries from the cache, generates random seeds for each process,
+    and collects rollouts in parallel using multiprocessing. The
+    collected rollouts are then used to update the cache and
+    accumulate successful entries.
 
     Returns:
         set[SuccessEntry]: A set of generated success entries.
+
     """
     rng = np.random.default_rng(hparams.seed)
 
@@ -410,40 +419,33 @@ def explore(
     state_sampler.update(state_sampler_cache_update)
 
     success_entries: set[SuccessEntry] = set()
-    for iteration in range(hparams.go_explore_num_iterations):
-        if iteration + 1 % 20 == 0:
-            print(
-                f"[Iteration {iteration}] Successes: {len(success_entries)} ({sorted([len(x.trajectory) for x in success_entries ])})"
-            )
-            x = next(sorted(success_entries, key=lambda e: len(e.trajectory)))
-            print("  Trajectory: ", x.trajectory)
-
-        start_entries = state_sampler.sample(
-            n=hparams.go_explore_num_samples_per_iteration
-        )
+        
+    def _get_tasks(total_task_count, new_task_count, current_best_trajectory_length):
+        start_entries = state_sampler.sample(n=new_task_count * hparams.go_explore_num_samples_per_worker_task)
         if hparams.debug:
             object_logger.log(
                 "start_entries.pkl",
-                OccurrenceLogEntry(batch_idx=iteration, object=start_entries),
+                OccurrenceLogEntry(batch_idx=total_task_count, object=start_entries),
             )
 
         seeds = rng.integers(low=0, high=2**31, size=len(start_entries))
         rngs = list(map(np.random.default_rng, seeds))
 
-        start_entries_chunked = chunked(start_entries, _WORK_PER_CHUNK)
-        rngs_chunked = chunked(rngs, _WORK_PER_CHUNK)
+        start_entries_chunked = chunked(start_entries, hparams.go_explore_num_samples_per_worker_task)
+        rngs_chunked = chunked(rngs, hparams.go_explore_num_samples_per_worker_task)
+        return [(current_best_trajectory_length, start_entries_chunk, rngs_chunk) for start_entries_chunk, rngs_chunk in zip(start_entries_chunked, rngs_chunked)]
 
-        _collect_rollouts = functools.partial(
-            rollout,
-            rollout_params,
-            state_sampler.current_best_trajectory_length,
-        )
 
-        with multiprocessing.Pool(processes=hparams.go_explore_num_processes) as pool:
-            for rollout_success_entries, state_sampler_cache_update in pool.starmap(
-                _collect_rollouts,
-                [*zip(start_entries_chunked, rngs_chunked)],
-            ):
+    def _process_results(count: int):
+        count_processed = 0
+        try:
+            for _ in range(count):
+                if count_processed == 0:
+                    # Block on the first, then process up to count in total.
+                    rollout_success_entries, state_sampler_cache_update = result_queue.get()
+                else:
+                    rollout_success_entries, state_sampler_cache_update = result_queue.get_nowait()
+
                 # Compile success entries from the current set of
                 # rollouts to build out the return value for this
                 # function.
@@ -452,6 +454,62 @@ def explore(
                 # iteration of exploratory rollouts.
                 state_sampler.update(state_sampler_cache_update)
 
+                count_processed += 1
+        except:
+            pass
+
+        return count_processed 
+
+    # Need to figure out why WORKERS ARE NOT DOING ANYTHING! no python work is happening. blocking.
+
+    # Push initial tasks.
+    task_target = hparams.go_explore_num_processes*2
+    task_queue = multiprocessing.Queue(maxsize=task_target)
+    result_queue = multiprocessing.Queue()
+
+    # Start worker processes.
+    _collect_rollouts = functools.partial(rollout, rollout_params)
+    workers = []
+    for _ in range(hparams.go_explore_num_processes):
+        workers.append(multiprocessing.Process(target=rollout_worker, args=(task_queue, result_queue, _collect_rollouts)))
+    for worker in workers:
+        worker.start()
+
+    total_task_count = 0
+    tasks_in_flight = 0
+    while True:
+        if total_task_count + 1 % 20 == 0:
+            print(
+                f"[Total Task Count {total_task_count}] Successes: {len(success_entries)} ({sorted([len(x.trajectory) for x in success_entries ])})"
+            )
+            x = next(sorted(success_entries, key=lambda e: len(e.trajectory)))
+            print("  Trajectory: ", x.trajectory)
+
+        
+        process_result_count = len(workers)
+        if total_task_count < hparams.go_explore_num_tasks:
+            for task in _get_tasks(total_task_count=total_task_count, new_task_count=task_target-tasks_in_flight, current_best_trajectory_length=state_sampler.current_best_trajectory_length):
+                task_queue.put(task)
+                tasks_in_flight +=1
+                total_task_count += 1
+                if total_task_count == hparams.go_explore_num_tasks:
+                    break
+        else:
+            # Clean up by posting sentinels.
+            for _ in range(len(workers)):
+                task_queue.put(None)
+            for worker in workers:
+                worker.join()
+            # Process all completed tasks.
+            tasks_in_flight -= _process_results(tasks_in_flight)
+            break
+            
+        # Process up to len(workers) results to balance batching and
+        # not being stuck until all the work-in-flight is done.
+        tasks_in_flight -= _process_results(len(workers))
+
+    assert tasks_in_flight == 0
+                
     if hparams.debug:
         object_logger.log(
             f"state_cache-{hparams.env_width}.pkl",

--- a/bridger/go_explore_phase_1.py
+++ b/bridger/go_explore_phase_1.py
@@ -473,8 +473,6 @@ def explore(
 
         return count_processed
 
-    # Need to figure out why WORKERS ARE NOT DOING ANYTHING! no python work is happening. blocking.
-
     # Push initial tasks.
     task_target = hparams.go_explore_num_processes * 2
     task_queue = multiprocessing.Queue(maxsize=task_target)

--- a/bridger/go_explore_phase_1.py
+++ b/bridger/go_explore_phase_1.py
@@ -430,7 +430,7 @@ def explore(
         )
         if hparams.debug:
             object_logger.log(
-                "start_entries-width-{hparams.env_width}.pkl",
+                f"start_entries-width-{hparams.env_width}.pkl",
                 OccurrenceLogEntry(batch_idx=total_task_count, object=start_entries),
             )
 
@@ -558,7 +558,7 @@ if __name__ == "__main__":
 
         for success_entry in success_entries:
             object_logger.log(
-                "success_entry-width-{hparams.env_width}.pkl", success_entry
+                f"success_entry-width-{hparams.env_width}.pkl", success_entry
             )
 
         print(

--- a/bridger/go_explore_phase_1.py
+++ b/bridger/go_explore_phase_1.py
@@ -371,11 +371,13 @@ def rollout_worker(task_queue, result_queue, rollout_func):
     while True:
         task = task_queue.get()
         if task is None:
+            task_queue.task_done()
             break
 
         result = rollout_func(*task)
         result_queue.put(result)
-
+        task_queue.task_done()
+    return None
 
 def explore(
     object_logger: ObjectLogManager,
@@ -445,12 +447,11 @@ def explore(
             )
         ]
 
-    def _process_results(count: int):
-        count_processed = 0
+    def _process_results(count: int, final_flush: bool = False):
+        # Block on the first, then process up to count in total.
         try:
-            for _ in range(count):
-                if count_processed == 0:
-                    # Block on the first, then process up to count in total.
+            for i in range(count):
+                if i == 0 or final_flush:
                     rollout_success_entries, state_sampler_cache_update = (
                         result_queue.get()
                     )
@@ -458,7 +459,7 @@ def explore(
                     rollout_success_entries, state_sampler_cache_update = (
                         result_queue.get_nowait()
                     )
-
+                    
                 # Compile success entries from the current set of
                 # rollouts to build out the return value for this
                 # function.
@@ -467,16 +468,15 @@ def explore(
                 # iteration of exploratory rollouts.
                 state_sampler.update(state_sampler_cache_update)
 
-                count_processed += 1
+                result_queue.task_done()
         except:
             pass
 
-        return count_processed
 
     # Push initial tasks.
     task_target = hparams.go_explore_num_processes * 2
-    task_queue = multiprocessing.Queue(maxsize=task_target)
-    result_queue = multiprocessing.Queue()
+    task_queue = multiprocessing.JoinableQueue(maxsize=task_target)
+    result_queue = multiprocessing.JoinableQueue()
 
     # Start worker processes.
     _collect_rollouts = functools.partial(rollout, rollout_params)
@@ -492,7 +492,6 @@ def explore(
         worker.start()
 
     total_task_count = 0
-    tasks_in_flight = 0
     while True:
         if total_task_count + 1 % 20 == 0:
             print(
@@ -501,34 +500,38 @@ def explore(
             x = next(sorted(success_entries, key=lambda e: len(e.trajectory)))
             print("  Trajectory: ", x.trajectory)
 
-        process_result_count = len(workers)
-        if total_task_count < hparams.go_explore_num_tasks:
-            for task in _get_tasks(
-                total_task_count=total_task_count,
-                new_task_count=task_target - tasks_in_flight,
-                current_best_trajectory_length=state_sampler.current_best_trajectory_length,
-            ):
-                task_queue.put(task)
-                tasks_in_flight += 1
-                total_task_count += 1
-                if total_task_count == hparams.go_explore_num_tasks:
-                    break
-        else:
+
+        if total_task_count == hparams.go_explore_num_tasks:
             # Clean up by posting sentinels.
             for _ in range(len(workers)):
                 task_queue.put(None)
+
+            task_queue.join()
+            
+            # Process all completed tasks.
+            _process_results(result_queue.qsize(), final_flush=True)
+            result_queue.join()
+
             for worker in workers:
                 worker.join()
-            # Process all completed tasks.
-            tasks_in_flight -= _process_results(tasks_in_flight)
-            break
 
+            break
+            
+        for task in _get_tasks(
+            total_task_count=total_task_count,
+            new_task_count=task_target - task_queue.qsize(),
+            current_best_trajectory_length=state_sampler.current_best_trajectory_length,
+        ):
+            task_queue.put(task)
+            total_task_count += 1
+            if total_task_count == hparams.go_explore_num_tasks:
+                break
+            
         # Process up to len(workers) results to balance batching and
         # not being stuck until all the work-in-flight is done.
-        tasks_in_flight -= _process_results(len(workers))
+        _process_results(len(workers))
 
-    assert tasks_in_flight == 0
-
+    
     if hparams.debug:
         object_logger.log(
             f"state_cache-width-{hparams.env_width}.pkl",

--- a/bridger/go_explore_phase_1.py
+++ b/bridger/go_explore_phase_1.py
@@ -376,6 +376,7 @@ def rollout_worker(task_queue, result_queue, rollout_func):
         result = rollout_func(*task)
         result_queue.put(result)
 
+
 def explore(
     object_logger: ObjectLogManager,
     hparams: Any,
@@ -419,9 +420,11 @@ def explore(
     state_sampler.update(state_sampler_cache_update)
 
     success_entries: set[SuccessEntry] = set()
-        
+
     def _get_tasks(total_task_count, new_task_count, current_best_trajectory_length):
-        start_entries = state_sampler.sample(n=new_task_count * hparams.go_explore_num_samples_per_worker_task)
+        start_entries = state_sampler.sample(
+            n=new_task_count * hparams.go_explore_num_samples_per_worker_task
+        )
         if hparams.debug:
             object_logger.log(
                 "start_entries.pkl",
@@ -431,10 +434,16 @@ def explore(
         seeds = rng.integers(low=0, high=2**31, size=len(start_entries))
         rngs = list(map(np.random.default_rng, seeds))
 
-        start_entries_chunked = chunked(start_entries, hparams.go_explore_num_samples_per_worker_task)
+        start_entries_chunked = chunked(
+            start_entries, hparams.go_explore_num_samples_per_worker_task
+        )
         rngs_chunked = chunked(rngs, hparams.go_explore_num_samples_per_worker_task)
-        return [(current_best_trajectory_length, start_entries_chunk, rngs_chunk) for start_entries_chunk, rngs_chunk in zip(start_entries_chunked, rngs_chunked)]
-
+        return [
+            (current_best_trajectory_length, start_entries_chunk, rngs_chunk)
+            for start_entries_chunk, rngs_chunk in zip(
+                start_entries_chunked, rngs_chunked
+            )
+        ]
 
     def _process_results(count: int):
         count_processed = 0
@@ -442,9 +451,13 @@ def explore(
             for _ in range(count):
                 if count_processed == 0:
                     # Block on the first, then process up to count in total.
-                    rollout_success_entries, state_sampler_cache_update = result_queue.get()
+                    rollout_success_entries, state_sampler_cache_update = (
+                        result_queue.get()
+                    )
                 else:
-                    rollout_success_entries, state_sampler_cache_update = result_queue.get_nowait()
+                    rollout_success_entries, state_sampler_cache_update = (
+                        result_queue.get_nowait()
+                    )
 
                 # Compile success entries from the current set of
                 # rollouts to build out the return value for this
@@ -458,12 +471,12 @@ def explore(
         except:
             pass
 
-        return count_processed 
+        return count_processed
 
     # Need to figure out why WORKERS ARE NOT DOING ANYTHING! no python work is happening. blocking.
 
     # Push initial tasks.
-    task_target = hparams.go_explore_num_processes*2
+    task_target = hparams.go_explore_num_processes * 2
     task_queue = multiprocessing.Queue(maxsize=task_target)
     result_queue = multiprocessing.Queue()
 
@@ -471,7 +484,12 @@ def explore(
     _collect_rollouts = functools.partial(rollout, rollout_params)
     workers = []
     for _ in range(hparams.go_explore_num_processes):
-        workers.append(multiprocessing.Process(target=rollout_worker, args=(task_queue, result_queue, _collect_rollouts)))
+        workers.append(
+            multiprocessing.Process(
+                target=rollout_worker,
+                args=(task_queue, result_queue, _collect_rollouts),
+            )
+        )
     for worker in workers:
         worker.start()
 
@@ -485,12 +503,15 @@ def explore(
             x = next(sorted(success_entries, key=lambda e: len(e.trajectory)))
             print("  Trajectory: ", x.trajectory)
 
-        
         process_result_count = len(workers)
         if total_task_count < hparams.go_explore_num_tasks:
-            for task in _get_tasks(total_task_count=total_task_count, new_task_count=task_target-tasks_in_flight, current_best_trajectory_length=state_sampler.current_best_trajectory_length):
+            for task in _get_tasks(
+                total_task_count=total_task_count,
+                new_task_count=task_target - tasks_in_flight,
+                current_best_trajectory_length=state_sampler.current_best_trajectory_length,
+            ):
                 task_queue.put(task)
-                tasks_in_flight +=1
+                tasks_in_flight += 1
                 total_task_count += 1
                 if total_task_count == hparams.go_explore_num_tasks:
                     break
@@ -503,13 +524,13 @@ def explore(
             # Process all completed tasks.
             tasks_in_flight -= _process_results(tasks_in_flight)
             break
-            
+
         # Process up to len(workers) results to balance batching and
         # not being stuck until all the work-in-flight is done.
         tasks_in_flight -= _process_results(len(workers))
 
     assert tasks_in_flight == 0
-                
+
     if hparams.debug:
         object_logger.log(
             f"state_cache-{hparams.env_width}.pkl",

--- a/bridger/go_explore_phase_1.py
+++ b/bridger/go_explore_phase_1.py
@@ -379,6 +379,7 @@ def rollout_worker(task_queue, result_queue, rollout_func):
         task_queue.task_done()
     return None
 
+
 def explore(
     object_logger: ObjectLogManager,
     hparams: Any,
@@ -459,7 +460,7 @@ def explore(
                     rollout_success_entries, state_sampler_cache_update = (
                         result_queue.get_nowait()
                     )
-                    
+
                 # Compile success entries from the current set of
                 # rollouts to build out the return value for this
                 # function.
@@ -471,7 +472,6 @@ def explore(
                 result_queue.task_done()
         except:
             pass
-
 
     # Push initial tasks.
     task_target = hparams.go_explore_num_processes * 2
@@ -500,14 +500,13 @@ def explore(
             x = next(sorted(success_entries, key=lambda e: len(e.trajectory)))
             print("  Trajectory: ", x.trajectory)
 
-
         if total_task_count == hparams.go_explore_num_tasks:
             # Clean up by posting sentinels.
             for _ in range(len(workers)):
                 task_queue.put(None)
 
             task_queue.join()
-            
+
             # Process all completed tasks.
             _process_results(result_queue.qsize(), final_flush=True)
             result_queue.join()
@@ -516,7 +515,7 @@ def explore(
                 worker.join()
 
             break
-            
+
         for task in _get_tasks(
             total_task_count=total_task_count,
             new_task_count=task_target - task_queue.qsize(),
@@ -526,12 +525,11 @@ def explore(
             total_task_count += 1
             if total_task_count == hparams.go_explore_num_tasks:
                 break
-            
+
         # Process up to len(workers) results to balance batching and
         # not being stuck until all the work-in-flight is done.
         _process_results(len(workers))
 
-    
     if hparams.debug:
         object_logger.log(
             f"state_cache-width-{hparams.env_width}.pkl",
@@ -559,7 +557,9 @@ if __name__ == "__main__":
         )
 
         for success_entry in success_entries:
-            object_logger.log("success_entry-width-{hparams.env_width}.pkl", success_entry)
+            object_logger.log(
+                "success_entry-width-{hparams.env_width}.pkl", success_entry
+            )
 
         print(
             f"==========\nEntry Count: {len(success_entries)}\n * wa-sampled: {hparams.go_explore_wa_sampled}\n * wa-new: {hparams.go_explore_wa_led_to_something_new}\n * wa-visit: {hparams.go_explore_wa_times_visited}\nShortest: {sorted([len(x.trajectory) for x in success_entries ])}"


### PR DESCRIPTION
make rollout workers run async relative to the cache updates in the main thread to increase throughput of rollouts. 